### PR TITLE
Reload URL hash after accepting TOS if applicable

### DIFF
--- a/app/assets/javascripts/accept_tos.js
+++ b/app/assets/javascripts/accept_tos.js
@@ -5,4 +5,11 @@ $(document).ready(function() {
     $("#content").hide();
     $("#tos").show();
   }
+  $("#tos_form").submit(function() {
+    /* save fragment (e.g. #reply-1234) for redirect */
+    if (location.hash) {
+      localStorage.setItem("tos.old_path", location.pathname);
+      localStorage.setItem("tos.old_fragment", location.hash);
+    }
+  });
 });

--- a/app/assets/javascripts/accept_tos.js
+++ b/app/assets/javascripts/accept_tos.js
@@ -8,8 +8,8 @@ $(document).ready(function() {
   $("#tos_form").submit(function() {
     /* save fragment (e.g. #reply-1234) for redirect */
     if (location.hash) {
-      localStorage.setItem("tos.old_path", location.pathname);
-      localStorage.setItem("tos.old_fragment", location.hash);
+      sessionStorage.setItem("tos.old_path", location.pathname);
+      sessionStorage.setItem("tos.old_fragment", location.hash);
     }
   });
 });

--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -28,6 +28,13 @@ $(document).ready(function() {
     }
   }
 
+  var oldPath = localStorage.getItem("tos.old_path");
+  if (oldPath && location.pathname === oldPath && !location.hash) {
+    location.hash = localStorage.getItem("tos.old_fragment");
+    localStorage.removeItem("tos.old_path");
+    localStorage.removeItem("tos.old_fragment");
+  }
+
   // Watch for login status change
   // Display warning prompting user to reload when it occurs
   window.addEventListener('storage', function(e) {

--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -28,11 +28,11 @@ $(document).ready(function() {
     }
   }
 
-  var oldPath = localStorage.getItem("tos.old_path");
+  var oldPath = sessionStorage.getItem("tos.old_path");
   if (oldPath && location.pathname === oldPath && !location.hash) {
-    location.hash = localStorage.getItem("tos.old_fragment");
-    localStorage.removeItem("tos.old_path");
-    localStorage.removeItem("tos.old_fragment");
+    location.hash = sessionStorage.getItem("tos.old_fragment");
+    sessionStorage.removeItem("tos.old_path");
+    sessionStorage.removeItem("tos.old_fragment");
   }
 
   // Watch for login status change

--- a/app/views/about/_accept_tos.haml
+++ b/app/views/about/_accept_tos.haml
@@ -2,7 +2,7 @@
   %table#signup.form-table
     %thead
       %tr
-        %th Accept our Terms of Service
+        %th.table-title Accept our Terms of Service
     %tbody
       %tr#terms
         %td.odd

--- a/app/views/about/_accept_tos.haml
+++ b/app/views/about/_accept_tos.haml
@@ -19,5 +19,5 @@
   = form_for current_user, url: current_user, method: :put, name: :tos_form do
     = content_for :tos_form
 - else
-  = form_tag confirm_tos_path, method: :patch do
+  = form_tag confirm_tos_path, method: :patch, id: :tos_form do
     = content_for :tos_form


### PR DESCRIPTION
This unfortunately has to be done by JavaScript because we submit the form to a POST page in the middle (and the resulting redirect has no access to the browser's fragment value, so it clears it). The checks are so that submitting the ToS on two different pages should still work here, and so it doesn't mess up unrelated page loads if somehow the action fails to complete.

There are very potentially edge cases, but it'd be, like, hitting submit on the TOS page, not loading the page afterwards, and then loading it at some point in the future (where it would then reload the fragment). This should be very rare, though, and only happens once, since it deletes the local storage value afterwards.

Oh, and the header of this TOS page wasn't showing right, so this fixes that too.