### PR TITLE
Timezoneify timestamps for logged out users

### DIFF
--- a/app/assets/javascripts/application_deferred.js
+++ b/app/assets/javascripts/application_deferred.js
@@ -1,0 +1,1 @@
+//= require datetimes

--- a/app/assets/javascripts/datetimes.js
+++ b/app/assets/javascripts/datetimes.js
@@ -1,0 +1,15 @@
+/* global gon */
+var options = {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+};
+var format = Intl.DateTimeFormat('en-US', options);
+
+window.onload = function() {
+  if (gon.logged_in) return;
+  var times = document.getElementsByTagName('time');
+  Array.from(times).forEach(function(time) {
+    var datetime = new Date(time.dateTime);
+    time.innerText = format.format(datetime);
+  });
+};

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,9 @@ module ApplicationHelper
 
   def pretty_time(time, format: nil)
     return unless time
-    time.strftime(format || current_user.try(:time_display) || TIME_FORMAT)
+    content_tag(:time, datetime: time.utc.iso8601, title: time.utc.strftime("%Y-%m-%d %H:%M %Z")) do
+      time.strftime(format || current_user.try(:time_display) || TIME_FORMAT)
+    end
   end
 
   def fun_name(user)

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -52,6 +52,7 @@
     %link{rel: 'manifest', href: asset_path('favicons/manifest.json')}
 
     = include_gon
+    = javascript_include_tag 'application_deferred'.freeze, defer: :defer
   %body
     #holder
       #header


### PR DESCRIPTION
Also affects flat posts - we cache the timestamps there, so I'm improving this to update them with JavaScript. For now, we make sure the string is very similar to our default format (changing from `Jun 22, 2019 4:38 AM` to `Jun 22, 2019, 4:38 AM`: note the comma), and always in en-US locale, to cohere better with the site, but we could reinvestigate this if we wanted.

Additionally, where we were using `pretty_time` to display timestamps, I've updated _all_ of them (even when logged in) to be wrapped in a `<time>` tag and to additionally show the UTC timestamp on hover.

On a technical level, I use a `<script>` tag with the `defer` attribute to try to reduce the amount the page flickers on load. However, other components (like Select2) already cause page flickering, so I don't think this is a significant consideration.

Note: after this change, we should regenerate flat posts so historical flat posts can take advantage of this feature.