### PR TITLE
Don't use default postgres port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - 5555:5555
 
 volumes:
   bundler-volume:


### PR DESCRIPTION
I ran into an issue where the postgres in the docker container was conflicting with my local postgres. Updating the glowfic postgres port to something other than the default fixed it.