### PR TITLE
Upgrade autoloader to zeitwerk

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,8 @@ module Glowfic
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
+    config.autoloader = :zeitwerk
+
     config.time_zone = 'Eastern Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
 


### PR DESCRIPTION
The old classic loader is removed in Rails 7

https://guides.rubyonrails.org/v7.0/classic_to_zeitwerk_howto.html

The steps mentioned in the related article passed fine for me (with an irrelevant deprecation warning)!

```
$ bin/rails runner 'p Rails.autoloaders.zeitwerk_enabled?'
`Redis.current` is deprecated and will be removed in 5.0. (called from: /home/throne3d/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/redis-namespace-1.8.2/lib/redis/namespace.rb:245:in `initialize')
true
$ bin/rails zeitwerk:check
`Redis.current` is deprecated and will be removed in 5.0. (called from: /home/throne3d/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/redis-namespace-1.8.2/lib/redis/namespace.rb:245:in `initialize')
Hold on, I am eager loading the application.
All is good!
```
And tests also passed locally =)