### PR TITLE
Update Actions references to main branch and references to repo URL

### DIFF
--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,7 +1,7 @@
 name: bundler-audit
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '20 20 * * 2'
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '44 5 * * 5'
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,7 +1,7 @@
 name: reviewdog
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   rubocop:
     name: rubocop

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,9 +6,9 @@ name: rspec
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This README mostly focuses on how to get started developing this project with Do
 
     *   Copy the code:
 
-        `git clone https://github.com/Marri/glowfic.git`
+        `git clone https://github.com/glowfic-constellation/glowfic.git`
 
 (More specific details, such as if you have write permission and wish to use SSH instead of HTTPS, may be found on the GitHub site.)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/Marri/glowfic.svg?branch=master)](https://travis-ci.com/Marri/glowfic) [![Test Coverage](https://codeclimate.com/github/Marri/glowfic/badges/coverage.svg)](https://codeclimate.com/github/Marri/glowfic/coverage)
+[![Build Status](https://github.com/glowfic-constellation/glowfic/actions/workflows/rspec.yml/badge.svg)](https://github.com/glowfic-constellation/glowfic/actions) [![Test Coverage](https://codeclimate.com/github/Marri/glowfic/badges/coverage.svg)](https://codeclimate.com/github/Marri/glowfic/coverage)
 
 ## README
 

--- a/app/views/contribute/index.haml
+++ b/app/views/contribute/index.haml
@@ -8,7 +8,7 @@
     %tr
       %td.odd= link_to 'Donate via Paypal', 'http://paypal.me/aschloss'
     %tr
-      %td.even= link_to 'Submit a pull request', 'https://github.com/Marri/glowfic'
+      %td.even= link_to 'Submit a pull request', 'https://github.com/glowfic-constellation/glowfic'
     %tr
       - if logged_in?
         %td.odd= link_to 'Write something!', new_post_path


### PR DESCRIPTION
We migrated Marri/glowfic to glowfic-constellation/glowfic, changed the default branch from master to main, and no longer use Travis CI =)