### PR TITLE
Fixes after CodeClimate lints

### DIFF
--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -17,6 +17,7 @@ $(document).ready(function() {
   });
 });
 
+// eslint-disable-next-line complexity
 function processDirectionalKey(event) {
   if ([keyLeft, keyUp, keyRight, keyDown].indexOf(event.which) < 0) return; // skip if not a directional key
   var tdBinding = $(this);

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -13,49 +13,49 @@ var keyDown = 40;
 $(document).ready(function() {
   fixButtons();
   $(".icon-row td:has(input)").each(function() {
-    $(this).keydown(function(event) {
-      if ([keyLeft, keyUp, keyRight, keyDown].indexOf(event.which) < 0) return; // skip if not a directional key
-      var input = $('input', this);
-      if (input.get(0).type !== 'text') { return; } // skip if not text
-      if (input.get(0).selectionStart !== input.get(0).selectionEnd) { return; } // skip processing if user has text selected
-      processDirectionalKey(event, input);
-    });
+    $(this).keydown(processDirectionalKey);
   });
 });
 
-function processDirectionalKey(event, input) {
+function processDirectionalKey(event) {
+  if ([keyLeft, keyUp, keyRight, keyDown].indexOf(event.which) < 0) return; // skip if not a directional key
+  var tdBinding = $(this);
+  var input = $('input', tdBinding);
+  if (input.get(0).type !== 'text') { return; } // skip if not text
+  if (input.get(0).selectionStart !== input.get(0).selectionEnd) { return; } // skip processing if user has text selected
+
   var caret = input.get(0).selectionStart;
-  var index = $(this).closest('td').index();
+  var index = tdBinding.closest('td').index();
 
   var consume = false;
   switch (event.which) {
   case keyLeft:
-    consume = processKeyLeft(caret);
+    consume = processKeyLeft(tdBinding, caret);
     break;
   case keyRight:
-    consume = processKeyRight(caret, input.val().length);
+    consume = processKeyRight(tdBinding, caret, input.val().length);
     break;
   case keyUp:
-    $(this).closest('tr').prev('.icon-row').children().eq(index).find('input').focus();
+    tdBinding.closest('tr').prev('.icon-row').children().eq(index).find('input').focus();
     consume = true;
     break;
   case keyDown:
-    $(this).closest('tr').next('.icon-row').children().eq(index).find('input').focus();
+    tdBinding.closest('tr').next('.icon-row').children().eq(index).find('input').focus();
     consume = true;
     break;
   }
   if (consume) event.preventDefault();
 }
 
-function processKeyLeft(caret) {
+function processKeyLeft(binding, caret) {
   if (caret !== 0) { return false; }
-  $(this).closest('td').prev().find('input').focus();
+  binding.closest('td').prev().find('input').focus();
   return true;
 }
 
-function processKeyRight(caret, length) {
-  if (caret <= length) { return false; }
-  $(this).closest('td').next().find('input').focus();
+function processKeyRight(binding, caret, length) {
+  if (caret < length) { return false; }
+  binding.closest('td').next().find('input').focus();
   return true;
 }
 

--- a/app/assets/javascripts/galleries/add_new.js
+++ b/app/assets/javascripts/galleries/add_new.js
@@ -98,7 +98,7 @@ function addNewRow() {
   urlField.show();
   urlField.attr('id', 'icons_'+index+'_url');
 
-  newRow.insertBefore($(".submit-row"));
+  newRow.insertAfter(oldRow);
   $("td:has(input)", newRow).each(function() {
     $(this).keydown(processDirectionalKey);
   });

--- a/app/assets/javascripts/galleries/uploader.js
+++ b/app/assets/javascripts/galleries/uploader.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
     var unusedUrls = uploadedUrls.filter(function(x) { return usedUrls.indexOf(x) < 0; });
     if (unusedUrls.length < 1) { return true; }
     deleteUnusedIcons($.map(unusedUrls, function(url) { return uploadedIcons[url]; }));
-    return false;
+    return true;
   });
 });
 

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -172,8 +172,8 @@ function setupWritableEditor() {
   $(document).click(function(e) {
     var target = e.target;
     hideSelect(target, iconSelectBox, '#current-icon-holder');
-    hideSelect(target, '#character-selector', '#swap-character');
-    hideSelect(target, '#alias-selector', '#swap-alias');
+    hideSelect(target, $('#character-selector'), '#swap-character');
+    hideSelect(target, $('#alias-selector'), '#swap-alias');
   });
 }
 


### PR DESCRIPTION
A few different issues from https://github.com/glowfic-constellation/glowfic/pull/1598:

* after 1727b67c8d83414e80c1aa75aaf23930a11da648, we're trying to call .hide on a plain string, rather than a jQuery object! Broke the post/reply editor character box disappearing when you click outside its box.
* after ec0a965b52c611a5ff29304fac6beb48c3be28f4, keybindings to quickly go through forms in the galleries#add_new page were broken by some scoping rules around $(this)
* (Unrelated issue: galleries#add_new's keybindings weren't working for new rows properly, because they were being inserted in the tfoot instead of the tbody)
* after 76546f877c2d133daa8528df42225e2e53dfe5f6, icon submit was broken after removing an uploaded icon and going through the deleteUnusedIcons flow, because jQuery event propagation was being blocked by `return false`