### PR TITLE
Fix minio icon upload with Docker approach

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -39,6 +39,8 @@ jobs:
       GLOWFIC_DATABASE_PORT: 5432
       CC_TEST_REPORTER_ID: 1e0c6dba9930e839038860b6d73301226c821937f57ed35d06fc0e4b7bddf5f6
       RAILS_ENV: test
+      MINIO_ENDPOINT: http://localhost:9000/
+      MINIO_ENDPOINT_EXTERNAL: http://localhost:9000/
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           wget --show-progress --progress=dot:mega https://dl.min.io/server/minio/release/linux-amd64/minio
           chmod +x minio
-          MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin ./minio server /data 2>&1 > minio.log &
+          MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin ./minio server ./minio-data 2>&1 > minio.log &
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/app/controllers/uploading_controller.rb
+++ b/app/controllers/uploading_controller.rb
@@ -7,12 +7,6 @@ class UploadingController < ApplicationController
 
     presign_conf = {}
     unless Rails.env.production?
-      if S3_BUCKET.nil?
-        logger.error "S3_BUCKET does not exist; icon upload will FAIL."
-        @s3_direct_post = Struct.new(:url, :fields).new('', nil)
-        return
-      end
-
       # for minio and Docker compatibility, replace the guest-compatible "minio" host with the host-compatible "localhost" path
       if ENV.key?('MINIO_ENDPOINT') && ENV.key?('MINIO_ENDPOINT_EXTERNAL')
         standard_endpoint = ENV.fetch('MINIO_ENDPOINT', nil)

--- a/app/controllers/uploading_controller.rb
+++ b/app/controllers/uploading_controller.rb
@@ -5,10 +5,24 @@ class UploadingController < ApplicationController
   def set_s3_url
     return if params[:type] == "existing"
 
-    if !Rails.env.production? && S3_BUCKET.nil?
-      logger.error "S3_BUCKET does not exist; icon upload will FAIL."
-      @s3_direct_post = Struct.new(:url, :fields).new('', nil)
-      return
+    presign_conf = {}
+    unless Rails.env.production?
+      if S3_BUCKET.nil?
+        logger.error "S3_BUCKET does not exist; icon upload will FAIL."
+        @s3_direct_post = Struct.new(:url, :fields).new('', nil)
+        return
+      end
+
+      # for minio and Docker compatibility, replace the guest-compatible "minio" host with the host-compatible "localhost" path
+      if ENV.key?('MINIO_ENDPOINT') && ENV.key?('MINIO_ENDPOINT_EXTERNAL')
+        standard_endpoint = ENV.fetch('MINIO_ENDPOINT', nil)
+        replacement_endpoint = ENV.fetch('MINIO_ENDPOINT_EXTERNAL', nil)
+        bucket_url = S3_BUCKET.url
+        unless bucket_url.include?(standard_endpoint)
+          raise RuntimeError.new("couldn't find minio endpoint in direct post URL: #{standard_endpoint} in #{bucket_url}")
+        end
+        presign_conf[:url] = bucket_url.sub(standard_endpoint, replacement_endpoint)
+      end
     end
 
     @s3_direct_post = S3_BUCKET.presigned_post(
@@ -17,6 +31,7 @@ class UploadingController < ApplicationController
       acl: 'public-read',
       content_type_starts_with: 'image/',
       cache_control: 'public, max-age=31536000',
+      **presign_conf,
     )
   end
 end

--- a/app/controllers/uploading_controller.rb
+++ b/app/controllers/uploading_controller.rb
@@ -6,17 +6,15 @@ class UploadingController < ApplicationController
     return if params[:type] == "existing"
 
     presign_conf = {}
-    unless Rails.env.production?
+    if !Rails.env.production? && ENV.key?('MINIO_ENDPOINT') && ENV.key?('MINIO_ENDPOINT_EXTERNAL')
       # for minio and Docker compatibility, replace the guest-compatible "minio" host with the host-compatible "localhost" path
-      if ENV.key?('MINIO_ENDPOINT') && ENV.key?('MINIO_ENDPOINT_EXTERNAL')
-        standard_endpoint = ENV.fetch('MINIO_ENDPOINT', nil)
-        replacement_endpoint = ENV.fetch('MINIO_ENDPOINT_EXTERNAL', nil)
-        bucket_url = S3_BUCKET.url
-        unless bucket_url.include?(standard_endpoint)
-          raise RuntimeError.new("couldn't find minio endpoint in direct post URL: #{standard_endpoint} in #{bucket_url}")
-        end
-        presign_conf[:url] = bucket_url.sub(standard_endpoint, replacement_endpoint)
+      standard_endpoint = ENV.fetch('MINIO_ENDPOINT', nil)
+      replacement_endpoint = ENV.fetch('MINIO_ENDPOINT_EXTERNAL', nil)
+      bucket_url = S3_BUCKET.url
+      unless bucket_url.include?(standard_endpoint)
+        raise RuntimeError.new("couldn't find minio endpoint in direct post URL: #{standard_endpoint} in #{bucket_url}")
       end
+      presign_conf[:url] = bucket_url.sub(standard_endpoint, replacement_endpoint)
     end
 
     @s3_direct_post = S3_BUCKET.presigned_post(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-env: &env
   AWS_SECRET_ACCESS_KEY: minioadmin
   S3_BUCKET_NAME: glowfic-dev
   MINIO_ENDPOINT: http://minio:9000/
+  MINIO_ENDPOINT_EXTERNAL: http://localhost:9000/
 x-svc: &svc
   build: .
   image: glowfic

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -680,7 +680,7 @@ RSpec.describe GalleriesController do
     end
 
     it "makes sure devs set up their S3 bucket correctly" do
-      fake_bucket = instance_double("Aws::S3::Bucket", url: "http://fake-url.example.com/my-bucket")
+      fake_bucket = instance_double(Aws::S3::Bucket, url: "http://fake-url.example.com/my-bucket")
       stub_const("S3_BUCKET", fake_bucket)
       allow(ENV).to receive(:fetch).with("MINIO_ENDPOINT", nil).and_return("http://invalid-url.example.com/")
       allow(ENV).to receive(:fetch).with("MINIO_ENDPOINT_EXTERNAL", nil).and_return("http://updated-url.example.com/")
@@ -689,7 +689,7 @@ RSpec.describe GalleriesController do
     end
 
     it "works with Docker minio mapping for devs" do
-      fake_bucket = instance_double("Aws::S3::Bucket", url: "http://old-url.example.com/my-bucket")
+      fake_bucket = instance_double(Aws::S3::Bucket, url: "http://old-url.example.com/my-bucket")
       stub_const("S3_BUCKET", fake_bucket)
       allow(ENV).to receive(:fetch).with("MINIO_ENDPOINT", nil).and_return("http://old-url.example.com/")
       allow(ENV).to receive(:fetch).with("MINIO_ENDPOINT_EXTERNAL", nil).and_return("http://updated-url.example.com/")

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -646,15 +646,6 @@ RSpec.describe GalleriesController do
       expect(flash[:error]).to eq("You do not have permission to modify this gallery.")
     end
 
-    it "correctly stubs S3 bucket for devs without storage service" do
-      stub_const("S3_BUCKET", nil)
-      login
-      get :add, params: { id: 0 }
-      expect(response).to render_template('add')
-      expect(assigns(:page_title)).to eq("Add Icons")
-      expect(assigns(:s3_direct_post)).to be_a(Struct)
-    end
-
     it "supports galleryless" do
       login
       get :add, params: { id: 0 }


### PR DESCRIPTION
The minio:9000 guest isn't usually available from the Docker host under that name, but instead binds to localhost with the given port. This allows the webserver to connect to minio directly inside the Docker network, and also allows the host to connect to the minio instance from the UI.