### PR TITLE
Improve CI/CD logging for streaming output

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -46,7 +46,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y chromium-browser
       - name: Set up MinIO
         run: |
-          wget https://dl.min.io/server/minio/release/linux-amd64/minio
+          wget --show-progress --progress=dot:mega https://dl.min.io/server/minio/release/linux-amd64/minio
           chmod +x minio
           MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin ./minio server /data 2>&1 > minio.log &
       - name: Set up Ruby
@@ -58,10 +58,16 @@ jobs:
       - name: Run rspec tests and report coverage
         uses: paambaati/codeclimate-action@v5.0.0
         with:
-          coverageCommand: bundle exec rspec spec
+          coverageCommand: bundle exec rspec spec --format documentation --format html --out rspec-results.html
       - name: Upload MinIO logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: minio-logs
           path: minio.log
+      - name: Upload RSpec logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: rspec-logs
+          path: rspec-results.html


### PR DESCRIPTION
GitHub Actions only shows output after linebreaks, so using the `documentation` output of RSpec lets us see partial results (including, I believe, failures) more rapidly, unlike the standard progress approach. The updated format prints each test it's running (easier to validate progres + see where it might be getting stuck), and outputs `FAILED` on the exact name that's breaking in the streaming logs if applicable, rather than us having to wait until the end to see the results.

Also the default `wget` verbosity is too high for the minio download, so I'm updating it to use dot:mega here.