### PR TITLE
Use case insensitive searches by default

### DIFF
--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::BoardsController < Api::ApiController
   param :page, :number, required: false, desc: 'Page in results (25 per page)'
   error 422, "Invalid parameters provided"
   def index
-    queryset = Board.where("name LIKE ?", params[:q].to_s + '%').ordered
+    queryset = Board.where("name ILIKE ?", params[:q].to_s + '%').ordered
     boards = paginate queryset, per_page: 25
     render json: { results: boards }
   end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::PostsController < Api::ApiController
   param :q, String, required: false, desc: 'Subject search term'
   def index
     queryset = Post.order(Arel.sql('LOWER(subject) asc'))
-    queryset = queryset.where('subject ILIKE ?', "%#{params[:q].downcase}%") if params[:q].present?
+    queryset = queryset.where('subject ILIKE ?', "%#{params[:q]}%") if params[:q].present?
 
     posts = paginate queryset, per_page: 25
     posts = posts.visible_to(current_user)

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::PostsController < Api::ApiController
   param :q, String, required: false, desc: 'Subject search term'
   def index
     queryset = Post.order(Arel.sql('LOWER(subject) asc'))
-    queryset = queryset.where('LOWER(subject) LIKE ?', "%#{params[:q].downcase}%") if params[:q].present?
+    queryset = queryset.where('subject ILIKE ?', "%#{params[:q].downcase}%") if params[:q].present?
 
     posts = paginate queryset, per_page: 25
     posts = posts.visible_to(current_user)

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::TagsController < Api::ApiController
   error 422, "Invalid parameters provided"
   def index
     type = find_type
-    queryset = type.where("name LIKE ?", params[:q].to_s + '%').ordered_by_name
+    queryset = type.where("name ILIKE ?", params[:q].to_s + '%').ordered_by_name
 
     # gallery groups only searches groups the specified user has used
     if (user_id = params[:user_id]) && type == GalleryGroup

--- a/app/controllers/api/v1/templates_controller.rb
+++ b/app/controllers/api/v1/templates_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::TemplatesController < Api::ApiController
   param :user_id, :number, required: false, desc: 'ID of the template user (optional)'
   error 422, "Invalid parameters provided"
   def index
-    queryset = Template.where("name LIKE ?", params[:q].to_s + '%').ordered
+    queryset = Template.where("name ILIKE ?", params[:q].to_s + '%').ordered
 
     if params[:user_id].present?
       return unless find_object(User, param: :user_id, status: :unprocessable_entity)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::UsersController < Api::ApiController
     queryset = if params[:match] == 'exact'
       User.where(username: params[:q])
     else
-      User.where("username LIKE ?", params[:q].to_s + '%').ordered
+      User.where("username ILIKE ?", params[:q].to_s + '%').ordered
     end
     if params[:hide_unblockable].present? && params[:hide_unblockable] == 'true' && logged_in?
       blocked_users = Block.where(blocking_user_id: current_user.id).pluck(:blocked_user_id)

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -286,9 +286,9 @@ class CharactersController < ApplicationController
 
     if params[:name].present?
       where_calc = []
-      where_calc << "name LIKE ?" if params[:search_name].present?
-      where_calc << "screenname LIKE ?" if params[:search_screenname].present?
-      where_calc << "nickname LIKE ?" if params[:search_nickname].present?
+      where_calc << "name ILIKE ?" if params[:search_name].present?
+      where_calc << "screenname ILIKE ?" if params[:search_screenname].present?
+      where_calc << "nickname ILIKE ?" if params[:search_nickname].present?
 
       @search_results = @search_results.where(where_calc.join(' OR '), *(['%' + params[:name].to_s + '%'] * where_calc.length))
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -286,10 +286,10 @@ class PostsController < WritableController
     @search_results = @search_results.where(id: Setting.find(params[:setting_id]).post_tags.pluck(:post_id)) if params[:setting_id].present?
     if params[:subject].present?
       if params[:abbrev].present?
-        search = params[:subject].downcase.chars.join('% ')
-        @search_results = @search_results.where('LOWER(subject) LIKE ?', "%#{search}%")
+        search = params[:subject].chars.join('% ')
+        @search_results = @search_results.where('subject ILIKE ?', "%#{search}%")
       else
-        @search_results = @search_results.search(params[:subject]).where('LOWER(subject) LIKE ?', "%#{params[:subject].downcase}%")
+        @search_results = @search_results.search(params[:subject]).where('subject ILIKE ?', "%#{params[:subject].downcase}%")
       end
     end
     @search_results = @search_results.complete if params[:completed].present?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -289,7 +289,7 @@ class PostsController < WritableController
         search = params[:subject].chars.join('% ')
         @search_results = @search_results.where('subject ILIKE ?', "%#{search}%")
       else
-        @search_results = @search_results.search(params[:subject]).where('subject ILIKE ?', "%#{params[:subject].downcase}%")
+        @search_results = @search_results.search(params[:subject]).where('subject ILIKE ?', "%#{params[:subject]}%")
       end
     end
     @search_results = @search_results.complete if params[:completed].present?

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -46,7 +46,7 @@ class RepliesController < WritableController
         exact_phrases.each do |phrase|
           phrase = phrase.first.strip
           next if phrase.blank?
-          @search_results = @search_results.where("replies.content LIKE ?", "%#{phrase}%")
+          @search_results = @search_results.where("replies.content ILIKE ?", "%#{phrase}%")
         end
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -136,7 +136,7 @@ class UsersController < ApplicationController
     @page_title = 'Search Users'
     return unless params[:commit].present?
     username = '%' + params[:username].to_s + '%'
-    @search_results = User.active.where("username LIKE ?", username).ordered.paginate(page: page)
+    @search_results = User.active.where("username ILIKE ?", username).ordered.paginate(page: page)
   end
 
   def output

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -32,7 +32,7 @@ class Character < ApplicationRecord
   after_destroy :clear_char_ids
 
   scope :ordered, -> { order(name: :asc).order(Arel.sql('lower(screenname) asc'), created_at: :asc, id: :asc) }
-  scope :with_name, ->(charname) { where("lower(concat_ws(' | ', name, nickname, screenname)) LIKE ?", "%#{charname.downcase}%") }
+  scope :with_name, ->(charname) { where("concat_ws(' | ', name, nickname, screenname) ILIKE ?", "%#{charname}%") }
 
   accepts_nested_attributes_for :template, reject_if: :all_blank
 

--- a/app/services/board/searcher.rb
+++ b/app/services/board/searcher.rb
@@ -9,7 +9,7 @@ class Board::Searcher < Object
       if params[:abbrev].present?
         search_acronym(params[:name])
       else
-        @search_results = @search_results.where("name LIKE ?", "%#{params[:name]}%")
+        @search_results = @search_results.where("name ILIKE ?", "%#{params[:name]}%")
       end
     end
     @search_results
@@ -24,7 +24,7 @@ class Board::Searcher < Object
   end
 
   def search_acronym(name)
-    search = name.downcase.chars.join('% ')
-    @search_results = @search_results.where('LOWER(name) LIKE ?', "%#{search}%")
+    search = name.chars.join('% ')
+    @search_results = @search_results.where('name ILIKE ?', "%#{search}%")
   end
 end

--- a/app/services/tag_searcher.rb
+++ b/app/services/tag_searcher.rb
@@ -6,7 +6,7 @@ class TagSearcher < Object
   def search(tag_name: nil, tag_type: nil, page: 1)
     validate_type!(tag_type) if tag_type.present?
 
-    @qs = @qs.where('name LIKE ?', "%#{tag_name}%") if tag_name.present?
+    @qs = @qs.where('name ILIKE ?', "%#{tag_name}%") if tag_name.present?
     @qs = @qs.where(type: tag_type) if tag_type.present?
     @qs = @qs.includes(:user) if tag_type == 'Setting'
     @qs = @qs.where.not(type: 'GalleryGroup') unless tag_type == 'GalleryGroup'

--- a/spec/controllers/replies/search_spec.rb
+++ b/spec/controllers/replies/search_spec.rb
@@ -133,17 +133,17 @@ RSpec.describe RepliesController, 'GET search' do
       expect(assigns(:search_results)).to match_array([reply, cap_reply])
     end
 
-    it "filters by exact match" do
+    it "filters by exact match case insensitively" do
       create(:reply, content: 'contains forks')
       create(:reply, content: 'Forks is capital')
-      reply = create(:reply, content: 'Forks High is capital')
-      create(:reply, content: 'Forks high is kinda capital')
-      create(:reply, content: 'forks High is different capital')
-      create(:reply, content: 'forks high is not capital')
+      reply1 = create(:reply, content: 'Forks High is capital')
+      reply2 = create(:reply, content: 'Forks high is kinda capital')
+      reply3 = create(:reply, content: 'forks High is different capital')
+      reply4 = create(:reply, content: 'forks high is not capital')
       create(:reply, content: 'Forks is split from High')
       create(:reply, content: 'nope')
       get :search, params: { commit: true, subj_content: '"Forks High"' }
-      expect(assigns(:search_results)).to match_array([reply])
+      expect(assigns(:search_results)).to match_array([reply1, reply2, reply3, reply4])
     end
 
     it "only shows from visible posts" do


### PR DESCRIPTION
Uses ILIKE for case insensitive searches (via database locale) rather than forcing downcase matches

Fixes #1247, and possibly other situations - though this might have undesirable effects in some situations if people are expecting case sensitive matches? I think all of these situations make sense to use case insensitive matches - including the API - but it's possible there are cases where we want case sensitivity that I'm not considering.