### PR TITLE
Convert #loading and #saveerror on reorder to classes

### DIFF
--- a/app/assets/javascripts/reorder.js
+++ b/app/assets/javascripts/reorder.js
@@ -119,7 +119,7 @@ function syncRowOrders(orderBox, path, param) {
   // Reduce race conditions by only allowing one update at a time
   unbindArrows(orderBox);
   disableSortable(orderBox);
-  $("#loading", orderBox).show();
+  $(".loading", orderBox).show();
   $(".saveconf", orderBox).stop(true, true).hide();
 
   // Switch the row order pre-emptively
@@ -152,14 +152,14 @@ function syncRowOrders(orderBox, path, param) {
     reorderRows(orderBox);
 
     // Re-enable the buttons
-    $("#loading", orderBox).hide();
+    $(".loading", orderBox).hide();
     $(".saveconf", orderBox).show().delay(2000).fadeOut();
     bindArrows(orderBox, path, param);
     enableSortable(orderBox);
   }).fail(function(resp) {
     // Display an error and debug to console, warn and block
-    $("#loading", orderBox).hide();
-    $("#saveerror", orderBox).show();
+    $(".loading", orderBox).hide();
+    $(".saveerror", orderBox).show();
     var sectionWarning = getOrCreateWarningBox(orderBox);
     var specificMessage = '';
     if (resp.status === 404) {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -409,7 +409,7 @@ tr.gallery-tags .tag-item { color: $font_color_tag_item_gallery; }
 .continuity-spacer { height: 20px; }
 .post-ignored { opacity: 0.3; }
 
-#loading img {
+.loading img {
   height: 20px;
   width: 20px;
 }

--- a/app/views/board_sections/edit.haml
+++ b/app/views/board_sections/edit.haml
@@ -20,8 +20,8 @@
   #reorder-posts-table
     .content-header
       Organize Section Posts
-      #loading.float-right.hidden= loading_tag
-      #saveerror.float-right.hidden
+      .loading.float-right.hidden= loading_tag
+      .saveerror.float-right.hidden
         = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
         Error, please refresh
       .saveconf.float-right.hidden

--- a/app/views/boards/_reorder_posts.haml
+++ b/app/views/boards/_reorder_posts.haml
@@ -2,9 +2,9 @@
 #reorder-posts-table
   .content-header
     Organize Unsectioned Posts
-    #loading.float-right.hidden
+    .loading.float-right.hidden
       = image_tag 'icons/loading.gif', title: 'Loading...', class: 'vmid', alt: '...', style: 'width: 16px; height: 16px;'
-    #saveerror.float-right.hidden
+    .saveerror.float-right.hidden
       = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
       Error, please refresh
     .saveconf.float-right.hidden

--- a/app/views/boards/_reorder_sections.haml
+++ b/app/views/boards/_reorder_sections.haml
@@ -2,8 +2,8 @@
 #reorder-sections-table
   .content-header
     = content_for :reorder_title
-    #loading.float-right.hidden= loading_tag # TODO duplicate id
-    #saveerror.float-right.hidden
+    .loading.float-right.hidden= loading_tag # TODO duplicate id
+    .saveerror.float-right.hidden
       -# TODO duplicate id
       = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
       Error, please refresh

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -84,8 +84,8 @@
       %tr
         %th.table-title
           Galleries
-          #loading.float-right.hidden= loading_tag
-          #saveerror.float-right.hidden
+          .loading.float-right.hidden= loading_tag
+          .saveerror.float-right.hidden
             = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
             Error, please refresh
           .saveconf.float-right.hidden


### PR DESCRIPTION
Fixes an issue with duplicate IDs on this page when handling both sections + sectionless posts.

Fixes #1151. Page still loads and the loading indicator shows up as expected - we were even already filtering our $("#loading, ...) scope to within a specific box, so it's not like it was expecting this to be globally distinct anyway.