### PR TITLE
Tweak default select2 height

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -300,6 +300,11 @@ td, .table-list li { font-size: $font_size_small; }
     color: $font_color_select2_container;
   }
 
+  &-container--default .select2-results > .select2-results__options {
+    // slightly increase height to show cut-off results (for platforms without clear scrollbars)
+    max-height: 220px;
+  }
+
   &, &-dropdown { font-size: $font_size_smallerish; }
 
   input {


### PR DESCRIPTION
Increasing this from 200px to 220px makes it clear that partial results are available, even on platforms without scrollbars (etc)

Before:

![image](https://github.com/glowfic-constellation/glowfic/assets/577128/63b1237c-c7e5-4309-b6f9-0ab0f9448095)


After:

![image](https://github.com/glowfic-constellation/glowfic/assets/577128/23e49574-0881-4d8c-baff-ba1f30c3f5d9)

Fixes #835