### PR TITLE
Show news 'new' link for mods too

### DIFF
--- a/app/concerns/permissible.rb
+++ b/app/concerns/permissible.rb
@@ -13,6 +13,7 @@ module Permissible
     # :edit_tags,
     # :delete_tags,
     # :edit_continuities
+    :create_news,
   ]
 
   def has_permission?(permission)

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -88,7 +88,7 @@ class NewsController < ApplicationController
   end
 
   def require_staff
-    return if current_user.admin? || current_user.mod?
+    return if current_user.has_permission?(:create_news)
     flash[:error] = "You do not have permission to manage news posts."
     redirect_to news_index_path
   end

--- a/app/views/news/index.haml
+++ b/app/views/news/index.haml
@@ -1,6 +1,6 @@
 .content-header
   Site News
-  - if current_user&.admin?
+  - if current_user&.admin? || current_user&.mod?
     = link_to new_news_path do
       .link-box.action-new + New News Post
 = render @news

--- a/app/views/news/index.haml
+++ b/app/views/news/index.haml
@@ -1,6 +1,6 @@
 .content-header
   Site News
-  - if current_user&.admin? || current_user&.mod?
+  - if current_user&.has_permission?(:create_news)
     = link_to new_news_path do
       .link-box.action-new + New News Post
 = render @news

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe NewsController do
 
       expect(NewsView.find_by(user: user).news).to eq(news)
     end
+
+    context "with views" do
+      render_views
+
+      it "does not show 'New' button for regular user" do
+        create(:news)
+        login
+        get :index
+        expect(response.body).not_to include("New News Post")
+      end
+
+      it "shows 'New' button for mod" do
+        create(:news)
+        login_as(create(:mod_user))
+        get :index
+        expect(response.body).to include("New News Post")
+      end
+    end
   end
 
   describe "GET new" do


### PR DESCRIPTION
News#new, #create, #edit, #update, #destroy all use require_staff, which allows both admins and mods to edit. Interestingly, it seems that editing a news post requires :edit_news permissions, which mods don't have, or for the mod to have created the news post in question. Here we create a :create_news permission that controls the power more clearly.