### PR TITLE
Fix alias display when reloading editor

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -223,12 +223,8 @@ function fixWritableFormCaching() {
       bindGallery();
     }
     setNPC(selectedNPC, isNPC);
-    if (selectedIconID !== displayIconID) {
-      setIconFromId(selectedIconID); // Handle the case where just the icon was cached
-    }
-    if (selectedAliasID !== displayAliasID) {
-      setAliasFromID(selectedAliasID);
-    }
+    setIconFromId(selectedIconID); // Handle the case where just the icon was cached
+    setAliasFromID(selectedAliasID);
   } else {
     getAndSetCharacterData({ id: selectedCharID, npc: isNPC, name: selectedNPC }, { restore_icon: true, restore_alias: true, updateCharDropdowns: true });
   }


### PR DESCRIPTION
After the NPC box change, the UI will show the base character name upon loading, even if an alias is selected (and persisting). Selecting an alias in the UI works fine - it's just when previewing it afterwards that things show up wrong in the editor - and persisting the alias is fine too.

Situations that go wrong:

1. Select an alias in the editor, click preview, the preview shows it correctly but the editor incorrectly shows the base character name
2. Open a post where you recently used a character with an alias, the editor incorrectly shows the base character name but upon post will use the alias

This solves both situations by guaranteeing there's always a sync between the selected ID and displayed ID on editor load after setting the UI for NPCs, and expands the same unconditional set to icons too. The conditional set doesn't seem to be necessary or helpful here, hence removing it!