### PR TITLE
Show NPCs on characters#index if in a template

### DIFF
--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -1,4 +1,5 @@
-- characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
+- characters = name.characters.ordered unless local_assigns[:characters]
+- characters = characters.non_npcs unless local_assigns[:show_npcs]
 - characters = characters.where(retired: false) unless show_retired
 
 - if @template.nil? && name.present?

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -1,6 +1,7 @@
 - col_count = 7
 - col_count += 1 if local_assigns[:show_template]
-- characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
+- characters = name.characters.ordered unless local_assigns[:characters]
+- characters = characters.non_npcs unless local_assigns[:show_npcs]
 - characters = characters.where(retired: false) unless show_retired
 
 - if @template.nil? && name.present?

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -67,7 +67,7 @@
       - if (group_chars = @user.characters.non_npcs.where(character_group_id: nil)).exists?
         = render 'group', characters: group_chars, group: nil, skip_grouped_templates: true, page_view: page_view, colspan: colspan
     - elsif @user.characters.exists?
-      = render partial: partial_type, collection: @user.templates.ordered, as: :name
+      = render partial: partial_type, collection: @user.templates.ordered, as: :name, show_npcs: true
       - if (templateless = @user.characters.non_npcs.where(template_id: nil)).exists?
         = render partial_type, name: "No Template", characters: templateless.ordered, show_new_character_button: @user.id == current_user&.id
     - else


### PR DESCRIPTION
In general they shouldn't be in a template, but just to make sure the interface is consistent with templates#show which currently shows the NPC (and seems better from a discoverability perspective).