### PR TITLE
Replace uglifier with terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,9 +43,9 @@ gem 'scout_apm'
 gem 'select2-rails'
 gem 'sprockets'
 gem 'sprockets-rails'
+gem 'terser'
 gem 'test-unit', '~> 3.6' # required by Heroku for production console
 gem 'tinymce-rails', '~> 5.10'
-gem 'uglifier'
 gem 'will_paginate'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,8 @@ GEM
     statsd-ruby (1.5.0)
     sysexits (1.2.0)
     temple (0.10.2)
+    terser (1.1.19)
+      execjs (>= 0.3.0, < 3)
     test-unit (3.6.1)
       power_assert
     thin (1.8.2)
@@ -461,8 +463,6 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)
@@ -542,12 +542,12 @@ DEPENDENCIES
   simplecov
   sprockets
   sprockets-rails
+  terser
   test-unit (~> 3.6)
   thin
   timecop
   tinymce-rails (~> 5.10)
   traceroute
-  uglifier
   webmock
   will_paginate
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   }
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Seems uglifier doesn't support ES6 properly (only experimentally) and is no longer maintained in favor of terser.