### PR TITLE
Replace ActiveDispatch::TestResponse#json with parsed_body

### DIFF
--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::ApiController do
         request.headers.merge({ Authorization: "Bearer definitely-invalid" })
         get :show, params: { id: 1 }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq("Authorization token is not valid.")
+        expect(response.parsed_body['errors'][0]['message']).to eq("Authorization token is not valid.")
       end
 
       it "displays an error if an expired token is provided" do
@@ -27,7 +27,7 @@ RSpec.describe Api::ApiController do
         Timecop.freeze(cur_time + Authentication::EXPIRY + 3.days) do
           get :show, params: { id: 1 }
           expect(response).to have_http_status(401)
-          expect(response.json['errors'][0]['message']).to eq("Authorization token has expired.")
+          expect(response.parsed_body['errors'][0]['message']).to eq("Authorization token has expired.")
         end
       end
 
@@ -35,7 +35,7 @@ RSpec.describe Api::ApiController do
         api_login
         get :show, params: { id: 1 }
         expect(response).to have_http_status(200)
-        expect(response.json['results'].size).to eq(3)
+        expect(response.parsed_body['results'].size).to eq(3)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Api::ApiController do
         request.headers.merge({ Authorization: "Bearer definitely-invalid" })
         get :index
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq("Authorization token is not valid.")
+        expect(response.parsed_body['errors'][0]['message']).to eq("Authorization token is not valid.")
       end
 
       it "displays an error if an expired token is provided" do
@@ -53,21 +53,21 @@ RSpec.describe Api::ApiController do
         Timecop.freeze(cur_time + Authentication::EXPIRY + 3.days) do
           get :index
           expect(response).to have_http_status(401)
-          expect(response.json['errors'][0]['message']).to eq("Authorization token has expired.")
+          expect(response.parsed_body['errors'][0]['message']).to eq("Authorization token has expired.")
         end
       end
 
       it "displays some data when logged out" do
         get :index
         expect(response).to have_http_status(200)
-        expect(response.json['results'].size).to eq(1)
+        expect(response.parsed_body['results'].size).to eq(1)
       end
 
       it "displays all data when logged in" do
         api_login
         get :index
         expect(response).to have_http_status(200)
-        expect(response.json['results'].size).to eq(2)
+        expect(response.parsed_body['results'].size).to eq(2)
       end
     end
   end

--- a/spec/controllers/api/v1/board_sections_controller_spec.rb
+++ b/spec/controllers/api/v1/board_sections_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V1::BoardSectionsController do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "requires a board you have access to" do
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       api_login_as(user)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq('Sections must be from one continuity')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Sections must be from one continuity')
       expect(board_section1.reload.section_order).to eq(0)
       expect(board_section2.reload.section_order).to eq(0)
       expect(board_section3.reload.section_order).to eq(1)
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       api_login_as(board.creator)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'][0]['message']).to eq('Some sections could not be found: -1')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Some sections could not be found: -1')
       expect(board_section1.reload.section_order).to eq(0)
       expect(board_section2.reload.section_order).to eq(1)
     end
@@ -80,7 +80,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       api_login_as(board.creator)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({ 'section_ids' => section_ids })
+      expect(response.parsed_body).to eq({ 'section_ids' => section_ids })
       expect(board_section1.reload.section_order).to eq(1)
       expect(board_section2.reload.section_order).to eq(3)
       expect(board_section3.reload.section_order).to eq(0)
@@ -108,7 +108,7 @@ RSpec.describe Api::V1::BoardSectionsController do
       api_login_as(board.creator)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({ 'section_ids' => [board_section3.id, board_section1.id, board_section2.id, board_section4.id] })
+      expect(response.parsed_body).to eq({ 'section_ids' => [board_section3.id, board_section1.id, board_section2.id, board_section4.id] })
       expect(board_section1.reload.section_order).to eq(1)
       expect(board_section2.reload.section_order).to eq(2)
       expect(board_section3.reload.section_order).to eq(0)

--- a/spec/controllers/api/v1/boards_controller_spec.rb
+++ b/spec/controllers/api/v1/boards_controller_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Api::V1::BoardsController do
       api_login
       get :index
       expect(response).to have_http_status(200)
-      expect(response.json['results'].count).to eq(8)
+      expect(response.parsed_body['results'].count).to eq(8)
     end
 
     it "works logged out", :show_in_doc do
       create_search_boards
       get :index, params: { q: 'b' }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].count).to eq(2)
+      expect(response.parsed_body['results'].count).to eq(2)
     end
 
     it "raises error on invalid page", :show_in_doc do
@@ -35,8 +35,8 @@ RSpec.describe Api::V1::BoardsController do
     it "requires valid board", :show_in_doc do
       get :show, params: { id: 0 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Continuity could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Continuity could not be found.")
     end
 
     it "succeeds with valid board" do
@@ -45,10 +45,10 @@ RSpec.describe Api::V1::BoardsController do
       section2 = create(:board_section, board: board)
       get :show, params: { id: board.id }
       expect(response).to have_http_status(200)
-      expect(response.json['id']).to eq(board.id)
-      expect(response.json['board_sections'].size).to eq(2)
-      expect(response.json['board_sections'][0]['id']).to eq(section1.id)
-      expect(response.json['board_sections'][1]['id']).to eq(section2.id)
+      expect(response.parsed_body['id']).to eq(board.id)
+      expect(response.parsed_body['board_sections'].size).to eq(2)
+      expect(response.parsed_body['board_sections'][0]['id']).to eq(section1.id)
+      expect(response.parsed_body['board_sections'][1]['id']).to eq(section2.id)
     end
 
     it "succeeds for logged in users with valid board" do
@@ -58,10 +58,10 @@ RSpec.describe Api::V1::BoardsController do
       section2 = create(:board_section, board: board)
       get :show, params: { id: board.id }
       expect(response).to have_http_status(200)
-      expect(response.json['id']).to eq(board.id)
-      expect(response.json['board_sections'].size).to eq(2)
-      expect(response.json['board_sections'][0]['id']).to eq(section1.id)
-      expect(response.json['board_sections'][1]['id']).to eq(section2.id)
+      expect(response.parsed_body['id']).to eq(board.id)
+      expect(response.parsed_body['board_sections'].size).to eq(2)
+      expect(response.parsed_body['board_sections'][0]['id']).to eq(section1.id)
+      expect(response.parsed_body['board_sections'][1]['id']).to eq(section2.id)
     end
 
     it "orders sections by section_order", :show_in_doc do
@@ -74,12 +74,12 @@ RSpec.describe Api::V1::BoardsController do
       section2.save!
       get :show, params: { id: board.id }
       expect(response).to have_http_status(200)
-      expect(response.json['id']).to eq(board.id)
-      expect(response.json['board_sections'].size).to eq(2)
-      expect(response.json['board_sections'][0]['id']).to eq(section2.id)
-      expect(response.json['board_sections'][0]['order']).to eq(0)
-      expect(response.json['board_sections'][1]['id']).to eq(section1.id)
-      expect(response.json['board_sections'][1]['order']).to eq(1)
+      expect(response.parsed_body['id']).to eq(board.id)
+      expect(response.parsed_body['board_sections'].size).to eq(2)
+      expect(response.parsed_body['board_sections'][0]['id']).to eq(section2.id)
+      expect(response.parsed_body['board_sections'][0]['order']).to eq(0)
+      expect(response.parsed_body['board_sections'][1]['id']).to eq(section1.id)
+      expect(response.parsed_body['board_sections'][1]['order']).to eq(1)
     end
   end
 
@@ -87,8 +87,8 @@ RSpec.describe Api::V1::BoardsController do
     it 'requires a valid board', :show_in_doc do
       get :posts, params: { id: 0 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Continuity could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Continuity could not be found.")
     end
 
     it 'filters non-public posts' do
@@ -96,8 +96,8 @@ RSpec.describe Api::V1::BoardsController do
       create(:post, privacy: :private, board: public_post.board)
       get :posts, params: { id: public_post.board_id }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].size).to eq(1)
-      expect(response.json['results'][0]['id']).to eq(public_post.id)
+      expect(response.parsed_body['results'].size).to eq(1)
+      expect(response.parsed_body['results'][0]['id']).to eq(public_post.id)
     end
 
     it 'returns only the correct posts', :show_in_doc do
@@ -108,24 +108,24 @@ RSpec.describe Api::V1::BoardsController do
       create(:post, board: create(:board))
       get :posts, params: { id: board.id }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].size).to eq(1)
-      expect(response.json['results'][0]['id']).to eq(user_post.id)
-      expect(response.json['results'][0]['board']['id']).to eq(user_post.board_id)
-      expect(response.json['results'][0]['section']['id']).to eq(user_post.section_id)
+      expect(response.parsed_body['results'].size).to eq(1)
+      expect(response.parsed_body['results'][0]['id']).to eq(user_post.id)
+      expect(response.parsed_body['results'][0]['board']['id']).to eq(user_post.board_id)
+      expect(response.parsed_body['results'][0]['section']['id']).to eq(user_post.section_id)
     end
 
     it 'paginates results' do
       board = create(:board)
       create_list(:post, 26, board: board)
       get :posts, params: { id: board.id }
-      expect(response.json['results'].size).to eq(25)
+      expect(response.parsed_body['results'].size).to eq(25)
     end
 
     it 'paginates results on additional pages' do
       board = create(:board)
       create_list(:post, 27, board: board)
       get :posts, params: { id: board.id, page: 2 }
-      expect(response.json['results'].size).to eq(2)
+      expect(response.parsed_body['results'].size).to eq(2)
     end
   end
 end

--- a/spec/controllers/api/v1/characters_controller_spec.rb
+++ b/spec/controllers/api/v1/characters_controller_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Api::V1::CharactersController do
   describe "GET index" do
-    shared_examples_for "index.json" do |in_doc|
+    shared_examples_for "index.parsed_body" do |in_doc|
       it "should support no search", show_in_doc: in_doc do
         char = create(:character)
         get :index
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "should support search" do
@@ -14,49 +14,49 @@ RSpec.describe Api::V1::CharactersController do
         create(:character, name: 'no') # char2
         get :index, params: { q: 'se' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "requires valid post id if provided", show_in_doc: in_doc do
         create(:character)
         get :index, params: { post_id: -1 }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'].size).to eq(1)
-        expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
+        expect(response.parsed_body['errors'].size).to eq(1)
+        expect(response.parsed_body['errors'][0]['message']).to eq("Post could not be found.")
       end
 
       it "requires valid template id if provided", show_in_doc: in_doc do
         create(:character)
         get :index, params: { template_id: 999 }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'].size).to eq(1)
-        expect(response.json['errors'][0]['message']).to eq("Template could not be found.")
+        expect(response.parsed_body['errors'].size).to eq(1)
+        expect(response.parsed_body['errors'][0]['message']).to eq("Template could not be found.")
       end
 
       it "requires valid user id if provided", show_in_doc: in_doc do
         character = create(:character)
         get :index, params: { user_id: character.user.id + 1 }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'].size).to eq(1)
-        expect(response.json['errors'][0]['message']).to eq("User could not be found.")
+        expect(response.parsed_body['errors'].size).to eq(1)
+        expect(response.parsed_body['errors'][0]['message']).to eq("User could not be found.")
       end
 
       it "requires valid includes if provided", show_in_doc: in_doc do
         create(:character)
         get :index, params: { includes: ['invalid'] }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'].size).to eq(1)
+        expect(response.parsed_body['errors'].size).to eq(1)
         expected = "Invalid parameter 'includes' value ['invalid']: Must be an array of ['default_icon', 'aliases', 'nickname']"
-        expect(response.json['errors'][0]['message']).to eq(expected)
+        expect(response.parsed_body['errors'][0]['message']).to eq(expected)
       end
 
       it "requires post with permission", show_in_doc: in_doc do
         post = create(:post, privacy: :private, with_character: true)
         get :index, params: { post_id: post.id }
         expect(response).to have_http_status(403)
-        expect(response.json['errors'].size).to eq(1)
-        expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+        expect(response.parsed_body['errors'].size).to eq(1)
+        expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
       end
 
       it "filters by post" do
@@ -65,8 +65,8 @@ RSpec.describe Api::V1::CharactersController do
         post = create(:post, character: char, user: char.user)
         get :index, params: { post_id: post.id }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "filters by template" do
@@ -75,8 +75,8 @@ RSpec.describe Api::V1::CharactersController do
         create(:character)
         get :index, params: { template_id: template.id }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "filters by templateless" do
@@ -85,8 +85,8 @@ RSpec.describe Api::V1::CharactersController do
         char = create(:character)
         get :index, params: { template_id: '0' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "filters by user id" do
@@ -95,59 +95,59 @@ RSpec.describe Api::V1::CharactersController do
         api_login_as(char2.user)
         get :index, params: { user_id: char.user_id }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "matches lowercase" do
         char = create(:character, name: 'Upcase')
         get :index, params: { q: 'upcase' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "matches uppercase" do
         char = create(:character, name: 'downcase')
         get :index, params: { q: 'DOWNcase' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "matches nickname" do
         char = create(:character, name: 'a', nickname: 'b', screenname: 'c')
         get :index, params: { q: 'b' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "matches screenname" do
         char = create(:character, name: 'a', nickname: 'b', screenname: 'c')
         get :index, params: { q: 'c' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
 
       it "matches midword" do
         char = create(:character, name: 'abcdefg')
         get :index, params: { q: 'cde' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(char.as_json(include: [:selector_name]).stringify_keys)
       end
     end
 
     context "when logged in" do
       before(:each) { api_login }
 
-      it_behaves_like "index.json", false
+      it_behaves_like "index.parsed_body", false
     end
 
     context "when logged out" do
-      it_behaves_like "index.json", true
+      it_behaves_like "index.parsed_body", true
     end
   end
 
@@ -155,15 +155,15 @@ RSpec.describe Api::V1::CharactersController do
     it "requires valid character", :show_in_doc do
       get :show, params: { id: -1 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Character could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Character could not be found.")
     end
 
     it "succeeds with valid character" do
       character = create(:character)
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['name']).to eq(character.name)
+      expect(response.parsed_body['name']).to eq(character.name)
     end
 
     it "succeeds for logged in users with valid character" do
@@ -171,7 +171,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['name']).to eq(character.name)
+      expect(response.parsed_body['name']).to eq(character.name)
     end
 
     it "has single gallery when present" do
@@ -179,7 +179,7 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries << create(:gallery, user: character.user)
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['galleries'].size).to eq(1)
+      expect(response.parsed_body['galleries'].size).to eq(1)
     end
 
     it "has single gallery when icon present" do
@@ -188,7 +188,7 @@ RSpec.describe Api::V1::CharactersController do
       character.save!
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['galleries'].size).to eq(1)
+      expect(response.parsed_body['galleries'].size).to eq(1)
     end
 
     it "returns icons in keyword order" do
@@ -201,8 +201,8 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries << gallery
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['galleries'].size).to eq(1)
-      expect(response.json['galleries'][0]['icons'].map { |i| i['keyword'] }).to eq(['xxx', 'yyy', 'zzz']) # rubocop:disable Rails/Pluck
+      expect(response.parsed_body['galleries'].size).to eq(1)
+      expect(response.parsed_body['galleries'][0]['icons'].map { |i| i['keyword'] }).to eq(['xxx', 'yyy', 'zzz']) # rubocop:disable Rails/Pluck
     end
 
     it "has associations when present", :show_in_doc do
@@ -212,9 +212,9 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries << create(:gallery, user: character.user, icon_count: 1)
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['galleries'].size).to eq(2)
-      expect(response.json['aliases'].size).to eq(1)
-      expect(response.json['aliases'].first['id']).to eq(calias.id)
+      expect(response.parsed_body['galleries'].size).to eq(2)
+      expect(response.parsed_body['aliases'].size).to eq(1)
+      expect(response.parsed_body['aliases'].first['id']).to eq(calias.id)
     end
 
     it "has galleries when icon_picker_grouping is false" do
@@ -226,23 +226,23 @@ RSpec.describe Api::V1::CharactersController do
       character.galleries[1].icons << create(:icon, user: user)
       get :show, params: { id: character.id }
       expect(response).to have_http_status(200)
-      expect(response.json['galleries'].size).to eq(1)
+      expect(response.parsed_body['galleries'].size).to eq(1)
     end
 
     it "requires post to exist when provided a post_id", :show_in_doc do
       character = create(:character)
       get :show, params: { id: character.id, post_id: 0 }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Post could not be found.")
     end
 
     it "requires post to have permission when provided a post_id", :show_in_doc do
       post = create(:post, privacy: :private, with_character: true)
       get :show, params: { id: post.character_id, post_id: post.id }
       expect(response).to have_http_status(403)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
 
     it "includes alias_id_for_post field when given post_id" do
@@ -250,8 +250,8 @@ RSpec.describe Api::V1::CharactersController do
       post = create(:post, user: character.user)
       get :show, params: { id: character.id, post_id: post.id }
       expect(response).to have_http_status(200)
-      expect(response.json).to have_key('alias_id_for_post')
-      expect(response.json['alias_id_for_post']).to be_nil
+      expect(response.parsed_body).to have_key('alias_id_for_post')
+      expect(response.parsed_body['alias_id_for_post']).to be_nil
     end
 
     it "sets correct alias_id_for_post when given post_id with recently used alias in post", :show_in_doc do
@@ -260,8 +260,8 @@ RSpec.describe Api::V1::CharactersController do
       post = create(:post, user: character.user, character: character, character_alias: calias)
       get :show, params: { id: character.id, post_id: post.id }
       expect(response).to have_http_status(200)
-      expect(response.json).to have_key('alias_id_for_post')
-      expect(response.json['alias_id_for_post']).to eq(calias.id)
+      expect(response.parsed_body).to have_key('alias_id_for_post')
+      expect(response.parsed_body['alias_id_for_post']).to eq(calias.id)
     end
 
     it "sets correct alias_id_for_post when given post_id with recently used alias in post" do
@@ -271,8 +271,8 @@ RSpec.describe Api::V1::CharactersController do
       create(:reply, post: post, user: character.user, character: character, character_alias: calias) # reply
       get :show, params: { id: character.id, post_id: post.id }
       expect(response).to have_http_status(200)
-      expect(response.json).to have_key('alias_id_for_post')
-      expect(response.json['alias_id_for_post']).to eq(calias.id)
+      expect(response.parsed_body).to have_key('alias_id_for_post')
+      expect(response.parsed_body['alias_id_for_post']).to eq(calias.id)
     end
   end
 
@@ -280,14 +280,14 @@ RSpec.describe Api::V1::CharactersController do
     it "requires login", :show_in_doc do
       put :update, params: { id: -1 }
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid character", :show_in_doc do
       api_login
       put :update, params: { id: -1 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'][0]['message']).to eq("Character could not be found.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Character could not be found.")
     end
 
     it "requires permission", :show_in_doc do
@@ -295,7 +295,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login
       put :update, params: { id: character.id }
       expect(response).to have_http_status(403)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
 
     it "does not change icon if invalid icon provided" do
@@ -304,7 +304,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(character.user)
       put :update, params: { id: character.id, character: { default_icon_id: -1 } }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq("Default icon could not be found")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Default icon could not be found")
       expect(character.reload.default_icon_id).to eq(icon.id)
     end
 
@@ -314,7 +314,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(character.user)
       put :update, params: { id: character.id, character: { default_icon_id: create(:icon).id } }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq("Default icon must be yours")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Default icon must be yours")
       expect(character.reload.default_icon_id).to eq(icon.id)
     end
 
@@ -324,7 +324,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(character.user)
       put :update, params: { id: character.id, character: { default_icon_id: '' } }
       expect(response.status).to eq(200)
-      expect(response.json['name']).to eq(character.name)
+      expect(response.parsed_body['name']).to eq(character.name)
       expect(character.reload.default_icon_id).to be_nil
     end
 
@@ -337,7 +337,7 @@ RSpec.describe Api::V1::CharactersController do
       put :update, params: { id: character.id, character: { default_icon_id: new_icon.id } }
 
       expect(response.status).to eq(200)
-      expect(response.json['name']).to eq(character.name)
+      expect(response.parsed_body['name']).to eq(character.name)
       expect(character.reload.default_icon_id).to eq(new_icon.id)
     end
 
@@ -350,7 +350,7 @@ RSpec.describe Api::V1::CharactersController do
       put :update, params: { id: character.id, character: { default_icon_id: new_icon.id, name: '', user_id: nil } }
 
       expect(response.status).to eq(422)
-      expect(response.json['errors'][0]['message']).to eq("Name can't be blank")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Name can't be blank")
       expect(character.reload.default_icon_id).to eq(icon.id)
       expect(character.reload.user_id).to eq(icon.user_id)
     end
@@ -360,7 +360,7 @@ RSpec.describe Api::V1::CharactersController do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "requires a character you have access to" do
@@ -395,7 +395,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(user)
       post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq('Character galleries must be from one character')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Character galleries must be from one character')
       expect(char_gal1.reload.section_order).to eq(0)
       expect(char_gal2.reload.section_order).to eq(0)
       expect(char_gal3.reload.section_order).to eq(1)
@@ -412,7 +412,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(character.user)
       post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'][0]['message']).to eq('Some character galleries could not be found: -1')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Some character galleries could not be found: -1')
       expect(char_gal1.reload.section_order).to eq(0)
       expect(char_gal2.reload.section_order).to eq(1)
     end
@@ -437,7 +437,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(character.user)
       post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({ 'characters_gallery_ids' => section_ids })
+      expect(response.parsed_body).to eq({ 'characters_gallery_ids' => section_ids })
       expect(char_gal1.reload.section_order).to eq(1)
       expect(char_gal2.reload.section_order).to eq(3)
       expect(char_gal3.reload.section_order).to eq(0)
@@ -465,7 +465,7 @@ RSpec.describe Api::V1::CharactersController do
       api_login_as(character.user)
       post :reorder, params: { ordered_characters_gallery_ids: section_ids }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({ 'characters_gallery_ids' => [char_gal3.id, char_gal1.id, char_gal2.id, char_gal4.id] })
+      expect(response.parsed_body).to eq({ 'characters_gallery_ids' => [char_gal3.id, char_gal1.id, char_gal2.id, char_gal4.id] })
       expect(char_gal1.reload.section_order).to eq(1)
       expect(char_gal2.reload.section_order).to eq(2)
       expect(char_gal3.reload.section_order).to eq(0)

--- a/spec/controllers/api/v1/galleries_controller_spec.rb
+++ b/spec/controllers/api/v1/galleries_controller_spec.rb
@@ -4,23 +4,23 @@ RSpec.describe Api::V1::GalleriesController do
       it "requires valid user", :show_in_doc do
         get :show, params: { id: '0' }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq("Gallery user could not be found.")
+        expect(response.parsed_body['errors'][0]['message']).to eq("Gallery user could not be found.")
       end
 
       it "returns galleryless icons for logged in user" do
         api_login
         get :show, params: { id: '0' }
         expect(response).to have_http_status(200)
-        expect(response.json['name']).to eq('Galleryless')
-        expect(response.json['icons']).to be_empty
+        expect(response.parsed_body['name']).to eq('Galleryless')
+        expect(response.parsed_body['icons']).to be_empty
       end
 
       it "returns galleryless icons for specified user", :show_in_doc do
         user = create(:user)
         get :show, params: { id: '0', user_id: user.id }
         expect(response).to have_http_status(200)
-        expect(response.json['name']).to eq('Galleryless')
-        expect(response.json['icons']).to be_empty
+        expect(response.parsed_body['name']).to eq('Galleryless')
+        expect(response.parsed_body['icons']).to be_empty
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::GalleriesController do
         expect(Gallery.find_by_id(1)).to be_nil
         get :show, params: { id: 1 }
         expect(response).to have_http_status(404)
-        expect(response.json['errors'][0]['message']).to eq("Gallery could not be found.")
+        expect(response.parsed_body['errors'][0]['message']).to eq("Gallery could not be found.")
       end
 
       it "displays the gallery", :show_in_doc do
@@ -38,9 +38,9 @@ RSpec.describe Api::V1::GalleriesController do
         api_login_as(gallery.user)
         get :show, params: { id: gallery.id }
         expect(response).to have_http_status(200)
-        expect(response.json['name']).to eq(gallery.name)
-        expect(response.json['icons'].size).to eq(1)
-        expect(response.json['icons'][0]['id']).to eq(gallery.icons.first.id)
+        expect(response.parsed_body['name']).to eq(gallery.name)
+        expect(response.parsed_body['icons'].size).to eq(1)
+        expect(response.parsed_body['icons'][0]['id']).to eq(gallery.icons.first.id)
       end
     end
   end

--- a/spec/controllers/api/v1/icons_controller_spec.rb
+++ b/spec/controllers/api/v1/icons_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V1::IconsController do
       expect(S3_BUCKET).not_to receive(:delete_objects)
       post :s3_delete
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "should require s3_key param" do
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::IconsController do
       api_login
       post :s3_delete
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq("Missing parameter s3_key")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Missing parameter s3_key")
     end
 
     it "should require your own icon" do
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::IconsController do
       post :s3_delete, params: { s3_key: "users/#{user.id}1/icons/hash_name.png" }
 
       expect(response).to have_http_status(403)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to modify this icon.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to modify this icon.")
     end
 
     it "should not allow deleting a URL in use" do
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::IconsController do
       expect(S3_BUCKET).not_to receive(:delete_objects)
       post :s3_delete, params: { s3_key: icon.s3_key }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq("Only unused icons can be deleted.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Only unused icons can be deleted.")
     end
 
     it "should delete the URL" do
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::IconsController do
       expect(S3_BUCKET).to receive(:delete_objects).with(delete_key)
       post :s3_delete, params: { s3_key: icon.s3_key }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({})
+      expect(response.parsed_body).to eq({})
     end
   end
 end

--- a/spec/controllers/api/v1/index_posts_controller_spec.rb
+++ b/spec/controllers/api/v1/index_posts_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V1::IndexPostsController do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     context "without index_section_id" do
@@ -39,7 +39,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one index')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one index')
         expect(index_post1.reload.section_order).to eq(0)
         expect(index_post2.reload.section_order).to eq(0)
         expect(index_post3.reload.section_order).to eq(1)
@@ -59,7 +59,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
         expect(index_post1.reload.section_order).to eq(0)
         expect(index_post2.reload.section_order).to eq(1)
       end
@@ -76,7 +76,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(404)
-        expect(response.json['errors'][0]['message']).to eq('Some posts could not be found: -1')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Some posts could not be found: -1')
       end
 
       it "works for valid changes", :show_in_doc do
@@ -99,7 +99,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(index.user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => post_ids })
+        expect(response.parsed_body).to eq({ 'post_ids' => post_ids })
         expect(index_post1.reload.section_order).to eq(1)
         expect(index_post2.reload.section_order).to eq(3)
         expect(index_post3.reload.section_order).to eq(0)
@@ -127,7 +127,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(index.user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => [index_post3.id, index_post1.id, index_post2.id, index_post4.id] })
+        expect(response.parsed_body).to eq({ 'post_ids' => [index_post3.id, index_post1.id, index_post2.id, index_post4.id] })
         expect(index_post1.reload.section_order).to eq(1)
         expect(index_post2.reload.section_order).to eq(2)
         expect(index_post3.reload.section_order).to eq(0)
@@ -171,7 +171,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: index_section1.id }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
         expect(index_post1.reload.section_order).to eq(0)
         expect(index_post2.reload.section_order).to eq(0)
         expect(index_post3.reload.section_order).to eq(1)
@@ -191,7 +191,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: 0 }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
         expect(index_post1.reload.section_order).to eq(0)
         expect(index_post2.reload.section_order).to eq(1)
       end
@@ -213,7 +213,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: index_section1.id }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
         expect(index_post1.reload.section_order).to eq(0)
         expect(index_post2.reload.section_order).to eq(0)
         expect(index_post3.reload.section_order).to eq(1)
@@ -233,7 +233,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: index_section.id }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the index, or no section')
         expect(index_post1.reload.section_order).to eq(0)
         expect(index_post2.reload.section_order).to eq(1)
       end
@@ -251,7 +251,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: index_section.id }
         expect(response).to have_http_status(404)
-        expect(response.json['errors'][0]['message']).to eq('Some posts could not be found: -1')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Some posts could not be found: -1')
       end
 
       it "works for valid changes", :show_in_doc do
@@ -275,7 +275,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(index.user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: index_section.id }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => post_ids })
+        expect(response.parsed_body).to eq({ 'post_ids' => post_ids })
         expect(index_post1.reload.section_order).to eq(1)
         expect(index_post2.reload.section_order).to eq(3)
         expect(index_post3.reload.section_order).to eq(0)
@@ -304,7 +304,7 @@ RSpec.describe Api::V1::IndexPostsController do
         api_login_as(index.user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: index_section.id }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => [index_post3.id, index_post1.id, index_post2.id, index_post4.id] })
+        expect(response.parsed_body).to eq({ 'post_ids' => [index_post3.id, index_post1.id, index_post2.id, index_post4.id] })
         expect(index_post1.reload.section_order).to eq(1)
         expect(index_post2.reload.section_order).to eq(2)
         expect(index_post3.reload.section_order).to eq(0)

--- a/spec/controllers/api/v1/index_sections_controller_spec.rb
+++ b/spec/controllers/api/v1/index_sections_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Api::V1::IndexSectionsController do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "requires a index you have access to" do
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::IndexSectionsController do
       api_login_as(user)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq('Sections must be from one index')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Sections must be from one index')
       expect(index_section1.reload.section_order).to eq(0)
       expect(index_section2.reload.section_order).to eq(0)
       expect(index_section3.reload.section_order).to eq(1)
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::IndexSectionsController do
       api_login_as(index.user)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'][0]['message']).to eq('Some sections could not be found: -1')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Some sections could not be found: -1')
       expect(index_section1.reload.section_order).to eq(0)
       expect(index_section2.reload.section_order).to eq(1)
     end
@@ -80,7 +80,7 @@ RSpec.describe Api::V1::IndexSectionsController do
       api_login_as(index.user)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({ 'section_ids' => section_ids })
+      expect(response.parsed_body).to eq({ 'section_ids' => section_ids })
       expect(index_section1.reload.section_order).to eq(1)
       expect(index_section2.reload.section_order).to eq(3)
       expect(index_section3.reload.section_order).to eq(0)
@@ -108,7 +108,7 @@ RSpec.describe Api::V1::IndexSectionsController do
       api_login_as(index.user)
       post :reorder, params: { ordered_section_ids: section_ids }
       expect(response).to have_http_status(200)
-      expect(response.json).to eq({ 'section_ids' => [index_section3.id, index_section1.id, index_section2.id, index_section4.id] })
+      expect(response.parsed_body).to eq({ 'section_ids' => [index_section3.id, index_section1.id, index_section2.id, index_section4.id] })
       expect(index_section1.reload.section_order).to eq(1)
       expect(index_section2.reload.section_order).to eq(2)
       expect(index_section3.reload.section_order).to eq(0)

--- a/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/spec/controllers/api/v1/posts_controller_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Api::V1::PostsController do
   describe "GET index" do
-    shared_examples_for "index.json" do |in_doc|
+    shared_examples_for "index.parsed_body" do |in_doc|
       it "should support no search", show_in_doc: in_doc do
         post = create(:post)
         get :index
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(post.as_json(min: true).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(post.as_json(min: true).stringify_keys)
       end
 
       it "should support search", show_in_doc: in_doc do
@@ -14,8 +14,8 @@ RSpec.describe Api::V1::PostsController do
         create(:post, subject: 'no') # post2
         get :index, params: { q: 'se' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(post.as_json(min: true).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(post.as_json(min: true).stringify_keys)
       end
 
       it "hides private posts" do
@@ -23,19 +23,19 @@ RSpec.describe Api::V1::PostsController do
         post = create(:post)
         get :index
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(post.as_json(min: true).stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(post.as_json(min: true).stringify_keys)
       end
     end
 
     context "when logged in" do
       before(:each) { api_login }
 
-      it_behaves_like "index.json", false
+      it_behaves_like "index.parsed_body", false
     end
 
     context "when logged out" do
-      it_behaves_like "index.json", true
+      it_behaves_like "index.parsed_body", true
     end
   end
 
@@ -43,28 +43,28 @@ RSpec.describe Api::V1::PostsController do
     it "requires valid post", :show_in_doc do
       get :show, params: { id: 0 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Post could not be found.")
     end
 
     it "requires access to post", :show_in_doc do
       post = create(:post, privacy: :private)
       get :show, params: { id: post.id }
       expect(response).to have_http_status(403)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
 
     it "succeeds with valid post", :show_in_doc do
       post = create(:post, with_icon: true, with_character: true)
       get :show, params: { id: post.id }
       expect(response).to have_http_status(200)
-      expect(response.json['id']).to eq(post.id)
-      expect(response.json['num_replies']).to eq(0)
-      expect(response.json['authors'].size).to eq(1)
-      expect(response.json['authors'][0]['id']).to eq(post.user_id)
-      expect(response.json['content']).to eq(post.content)
-      expect(response.json['icon']['id']).to eq(post.icon_id)
-      expect(response.json['character']['id']).to eq(post.character_id)
+      expect(response.parsed_body['id']).to eq(post.id)
+      expect(response.parsed_body['num_replies']).to eq(0)
+      expect(response.parsed_body['authors'].size).to eq(1)
+      expect(response.parsed_body['authors'][0]['id']).to eq(post.user_id)
+      expect(response.parsed_body['content']).to eq(post.content)
+      expect(response.parsed_body['icon']['id']).to eq(post.icon_id)
+      expect(response.parsed_body['character']['id']).to eq(post.character_id)
     end
   end
 
@@ -72,15 +72,15 @@ RSpec.describe Api::V1::PostsController do
     it "requires login", :show_in_doc do
       patch :update, params: { id: 0 }
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     it "requires valid post", :show_in_doc do
       api_login
       patch :update, params: { id: 0 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Post could not be found.")
     end
 
     it "requires access to post", :show_in_doc do
@@ -88,7 +88,7 @@ RSpec.describe Api::V1::PostsController do
       post = create(:post, privacy: :private)
       patch :update, params: { id: post.id }
       expect(response).to have_http_status(403)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
 
     it "requires private_note param", :show_in_doc do
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::PostsController do
       post = create(:post)
       patch :update, params: { id: post.id }
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq("Missing parameter private_note")
+      expect(response.parsed_body['errors'][0]['message']).to eq("Missing parameter private_note")
     end
 
     it "requires authorship of post" do
@@ -104,7 +104,7 @@ RSpec.describe Api::V1::PostsController do
       post = create(:post)
       patch :update, params: { id: post.id, private_note: "Shiny new note" }
       expect(response).to have_http_status(403)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
 
     it "handles failed saves" do
@@ -121,7 +121,7 @@ RSpec.describe Api::V1::PostsController do
       patch :update, params: { id: post.id, private_note: 'Shiny new note' }
 
       expect(response).to have_http_status(422)
-      expect(response.json['errors'][0]['message']).to eq('Post could not be updated.')
+      expect(response.parsed_body['errors'][0]['message']).to eq('Post could not be updated.')
     end
 
     it "succeeds with valid post", :show_in_doc do
@@ -132,7 +132,7 @@ RSpec.describe Api::V1::PostsController do
       patch :update, params: { id: post.id, private_note: 'Shiny new note' }
 
       expect(response).to have_http_status(200)
-      expect(response.json['private_note']).to eq("<p>Shiny new note</p>")
+      expect(response.parsed_body['private_note']).to eq("<p>Shiny new note</p>")
       expect(post.author_for(user).private_note).to eq('Shiny new note')
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe Api::V1::PostsController do
     it "requires login", :show_in_doc do
       post :reorder
       expect(response).to have_http_status(401)
-      expect(response.json['errors'][0]['message']).to eq("You must be logged in to view that page.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You must be logged in to view that page.")
     end
 
     context "without section_id" do
@@ -177,7 +177,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one continuity')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one continuity')
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(0)
         expect(board_post3.reload.section_order).to eq(1)
@@ -197,7 +197,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(1)
       end
@@ -214,7 +214,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(404)
-        expect(response.json['errors'][0]['message']).to eq('Some posts could not be found: -1')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Some posts could not be found: -1')
       end
 
       it "works for valid changes", :show_in_doc do
@@ -237,7 +237,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(board.creator)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => post_ids })
+        expect(response.parsed_body).to eq({ 'post_ids' => post_ids })
         expect(board_post1.reload.section_order).to eq(1)
         expect(board_post2.reload.section_order).to eq(3)
         expect(board_post3.reload.section_order).to eq(0)
@@ -265,7 +265,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(board.creator)
         post :reorder, params: { ordered_post_ids: post_ids }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => [board_post3.id, board_post1.id, board_post2.id, board_post4.id] })
+        expect(response.parsed_body).to eq({ 'post_ids' => [board_post3.id, board_post1.id, board_post2.id, board_post4.id] })
         expect(board_post1.reload.section_order).to eq(1)
         expect(board_post2.reload.section_order).to eq(2)
         expect(board_post3.reload.section_order).to eq(0)
@@ -309,7 +309,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: board_section1.id }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(0)
         expect(board_post3.reload.section_order).to eq(1)
@@ -329,7 +329,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: 0 }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(1)
       end
@@ -351,7 +351,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: board_section1.id }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(0)
         expect(board_post3.reload.section_order).to eq(1)
@@ -371,7 +371,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(422)
-        expect(response.json['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Posts must be from one specified section in the continuity, or no section')
         expect(board_post1.reload.section_order).to eq(0)
         expect(board_post2.reload.section_order).to eq(1)
       end
@@ -389,7 +389,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(user)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(404)
-        expect(response.json['errors'][0]['message']).to eq('Some posts could not be found: -1')
+        expect(response.parsed_body['errors'][0]['message']).to eq('Some posts could not be found: -1')
       end
 
       it "works for valid changes", :show_in_doc do
@@ -413,7 +413,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(board.creator)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => post_ids })
+        expect(response.parsed_body).to eq({ 'post_ids' => post_ids })
         expect(board_post1.reload.section_order).to eq(1)
         expect(board_post2.reload.section_order).to eq(3)
         expect(board_post3.reload.section_order).to eq(0)
@@ -442,7 +442,7 @@ RSpec.describe Api::V1::PostsController do
         api_login_as(board.creator)
         post :reorder, params: { ordered_post_ids: post_ids, section_id: section.id }
         expect(response).to have_http_status(200)
-        expect(response.json).to eq({ 'post_ids' => [board_post3.id, board_post1.id, board_post2.id, board_post4.id] })
+        expect(response.parsed_body).to eq({ 'post_ids' => [board_post3.id, board_post1.id, board_post2.id, board_post4.id] })
         expect(board_post1.reload.section_order).to eq(1)
         expect(board_post2.reload.section_order).to eq(2)
         expect(board_post3.reload.section_order).to eq(0)

--- a/spec/controllers/api/v1/replies_controller_spec.rb
+++ b/spec/controllers/api/v1/replies_controller_spec.rb
@@ -3,15 +3,15 @@ RSpec.describe Api::V1::RepliesController do
     it "requires valid post", :show_in_doc do
       get :index, params: { post_id: 0 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("Post could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("Post could not be found.")
     end
 
     it "requires access to post", :show_in_doc do
       post = create(:post, privacy: :private)
       get :index, params: { post_id: post.id }
       expect(response).to have_http_status(403)
-      expect(response.json['errors'][0]['message']).to eq("You do not have permission to perform this action.")
+      expect(response.parsed_body['errors'][0]['message']).to eq("You do not have permission to perform this action.")
     end
 
     it "succeeds with valid post", :show_in_doc do
@@ -21,12 +21,12 @@ RSpec.describe Api::V1::RepliesController do
       expect(calias.name).not_to eq(reply.character.name)
       get :index, params: { post_id: post.id }
       expect(response).to have_http_status(200)
-      expect(response.json.size).to eq(3)
-      expect(response.json[2]['id']).to eq(reply.id)
-      expect(response.json[2]['icon']['id']).to eq(reply.icon_id)
-      expect(response.json[2]['character']['id']).to eq(reply.character_id)
-      expect(response.json[2]['character']['name']).to eq(calias.character.name)
-      expect(response.json[2]['character_name']).to eq(calias.name)
+      expect(response.parsed_body.size).to eq(3)
+      expect(response.parsed_body[2]['id']).to eq(reply.id)
+      expect(response.parsed_body[2]['icon']['id']).to eq(reply.icon_id)
+      expect(response.parsed_body[2]['character']['id']).to eq(reply.character_id)
+      expect(response.parsed_body[2]['character']['name']).to eq(calias.character.name)
+      expect(response.parsed_body[2]['character_name']).to eq(calias.name)
     end
 
     it "paginates" do
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::RepliesController do
       expect(response.headers['Page'].to_i).to eq(3)
       expect(response.headers['Total'].to_i).to eq(5)
       expect(response.headers['Link']).not_to be_nil
-      expect(response.json.size).to eq(1)
+      expect(response.parsed_body.size).to eq(1)
     end
   end
 end

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -1,43 +1,43 @@
 RSpec.describe Api::V1::TagsController do
   describe "GET index" do
-    shared_examples_for "index.json" do |in_doc|
+    shared_examples_for "index.parsed_body" do |in_doc|
       it "should support label search", show_in_doc: in_doc do
         tag = create(:label)
         get :index, params: { q: tag.name, t: 'Label' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
       it "should support setting search", show_in_doc: in_doc do
         tag = create(:setting)
         get :index, params: { q: tag.name, t: 'Setting' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
       it "should support content warning search", show_in_doc: in_doc do
         tag = create(:content_warning)
         get :index, params: { q: tag.name, t: 'ContentWarning' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
       it "should support gallery group search" do
         tag = create(:gallery_group)
         get :index, params: { q: tag.name, t: 'GalleryGroup' }
         expect(response).to have_http_status(200)
-        expect(response.json).to have_key('results')
-        expect(response.json['results']).to contain_exactly(tag.as_json.stringify_keys)
+        expect(response.parsed_body).to have_key('results')
+        expect(response.parsed_body['results']).to contain_exactly(tag.as_json.stringify_keys)
       end
 
       it "should handle invalid input", show_in_doc: in_doc do
         get :index, params: { t: 'b' }
         expect(response).to have_http_status(422)
-        expect(response.json).to have_key('errors')
-        expect(response.json['errors'].first['message']).to include("Invalid parameter 't'")
+        expect(response.parsed_body).to have_key('errors')
+        expect(response.parsed_body['errors'].first['message']).to include("Invalid parameter 't'")
       end
 
       context "in gallery group search with user_id" do
@@ -46,8 +46,8 @@ RSpec.describe Api::V1::TagsController do
           ungrouped_tag = create(:gallery_group)
           get :index, params: { q: ungrouped_tag.name, t: 'GalleryGroup', user_id: user.id }
           expect(response).to have_http_status(200)
-          expect(response.json).to have_key('results')
-          expect(response.json['results']).to eq([])
+          expect(response.parsed_body).to have_key('results')
+          expect(response.parsed_body['results']).to eq([])
         end
 
         it "should display tags used on galleries" do
@@ -56,8 +56,8 @@ RSpec.describe Api::V1::TagsController do
           create(:gallery, user: user, gallery_groups: [gal_grouped_tag])
           get :index, params: { q: gal_grouped_tag.name, t: 'GalleryGroup', user_id: user.id }
           expect(response).to have_http_status(200)
-          expect(response.json).to have_key('results')
-          expect(response.json['results']).to contain_exactly(gal_grouped_tag.as_json.stringify_keys)
+          expect(response.parsed_body).to have_key('results')
+          expect(response.parsed_body['results']).to contain_exactly(gal_grouped_tag.as_json.stringify_keys)
         end
 
         it "should display tags used on characters" do
@@ -66,8 +66,8 @@ RSpec.describe Api::V1::TagsController do
           create(:character, user: user, gallery_groups: [char_grouped_tag])
           get :index, params: { q: char_grouped_tag.name, t: 'GalleryGroup', user_id: user.id }
           expect(response).to have_http_status(200)
-          expect(response.json).to have_key('results')
-          expect(response.json['results']).to contain_exactly(char_grouped_tag.as_json.stringify_keys)
+          expect(response.parsed_body).to have_key('results')
+          expect(response.parsed_body['results']).to contain_exactly(char_grouped_tag.as_json.stringify_keys)
         end
       end
     end
@@ -75,11 +75,11 @@ RSpec.describe Api::V1::TagsController do
     context "when logged in" do
       before(:each) { api_login }
 
-      it_behaves_like "index.json", false
+      it_behaves_like "index.parsed_body", false
     end
 
     context "when logged out" do
-      it_behaves_like "index.json", true
+      it_behaves_like "index.parsed_body", true
     end
   end
 
@@ -91,9 +91,9 @@ RSpec.describe Api::V1::TagsController do
       create(:gallery, gallery_groups: [group])
       get :show, params: { id: group.id, user_id: user.id }
       expect(response).to have_http_status(200)
-      expect(response.json['id']).to eq(group.id)
-      expect(response.json['text']).to eq(group.name)
-      expect(response.json['gallery_ids']).to match_array(galleries.map(&:id))
+      expect(response.parsed_body['id']).to eq(group.id)
+      expect(response.parsed_body['text']).to eq(group.name)
+      expect(response.parsed_body['gallery_ids']).to match_array(galleries.map(&:id))
     end
 
     [:setting, :label, :content_warning].each do |type|
@@ -101,15 +101,15 @@ RSpec.describe Api::V1::TagsController do
         tag = create(type) # rubocop:disable Rails/SaveBang
         get :show, params: { id: tag.id }
         expect(response).to have_http_status(200)
-        expect(response.json['id']).to eq(tag.id)
+        expect(response.parsed_body['id']).to eq(tag.id)
       end
     end
 
     it "should handle invalid tag", :show_in_doc do
       get :show, params: { id: 99 }
       expect(response).to have_http_status(404)
-      expect(response.json).to have_key('errors')
-      expect(response.json['errors'][0]['message']).to eq("Tag could not be found")
+      expect(response.parsed_body).to have_key('errors')
+      expect(response.parsed_body['errors'][0]['message']).to eq("Tag could not be found")
     end
   end
 end

--- a/spec/controllers/api/v1/templates_controller_spec.rb
+++ b/spec/controllers/api/v1/templates_controller_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Api::V1::TemplatesController do
       api_login
       get :index
       expect(response).to have_http_status(200)
-      expect(response.json['results'].count).to eq(8)
+      expect(response.parsed_body['results'].count).to eq(8)
     end
 
     it "works logged out", :show_in_doc do
       create_search_templates
       get :index, params: { q: 'b' }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].count).to eq(2)
+      expect(response.parsed_body['results'].count).to eq(2)
     end
 
     it "raises error on invalid page", :show_in_doc do
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::TemplatesController do
       create(:template, user: notuser) # nottemplate
 
       get :index, params: { user_id: template.user_id }
-      expect(response.json['results'].count).to eq(1)
+      expect(response.parsed_body['results'].count).to eq(1)
     end
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Api::V1::UsersController do
       api_login
       get :index
       expect(response).to have_http_status(200)
-      expect(response.json['results'].count).to eq(9)
+      expect(response.parsed_body['results'].count).to eq(9)
     end
 
     it "works logged out", :show_in_doc do
       create_search_users
       get :index, params: { q: 'b' }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].count).to eq(2)
+      expect(response.parsed_body['results'].count).to eq(2)
     end
 
     it "raises error on invalid page", :show_in_doc do
@@ -34,7 +34,7 @@ RSpec.describe Api::V1::UsersController do
       create(:user, username: 'alicorn')
       create(:user, username: 'ali')
       get :index, params: { q: 'ali', match: 'exact' }
-      expect(response.json['results'].count).to eq(1)
+      expect(response.parsed_body['results'].count).to eq(1)
     end
 
     it "handles hiding unblockable users" do
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::UsersController do
       create_list(:block, 2, blocking_user: user)
       create_list(:user, 3)
       get :index, params: { hide_unblockable: true }
-      expect(response.json['results'].count).to eq(3)
+      expect(response.parsed_body['results'].count).to eq(3)
     end
 
     it "does not hide unblockable users unless that parameter is sent" do
@@ -52,21 +52,21 @@ RSpec.describe Api::V1::UsersController do
       create_list(:block, 2, blocking_user: user)
       create_list(:user, 3)
       get :index
-      expect(response.json['results'].count).to eq(6)
+      expect(response.parsed_body['results'].count).to eq(6)
     end
 
     it "does not return deleted users" do
       create(:user, deleted: true)
       create(:user)
       get :index
-      expect(response.json['results'].count).to eq(1)
+      expect(response.parsed_body['results'].count).to eq(1)
     end
 
     it "shows moieties appropriately" do
       create(:user, username: 'Throne3d', moiety: '960018', moiety_name: 'Carmine')
       create(:user, username: 'anon')
       get :index
-      expect(response.json['results']).to contain_exactly(
+      expect(response.parsed_body['results']).to contain_exactly(
         a_collection_including(
           'username'    => 'Throne3d',
           'moiety'      => '960018',
@@ -85,8 +85,8 @@ RSpec.describe Api::V1::UsersController do
     it 'requires a valid user', :show_in_doc do
       get :posts, params: { id: 0 }
       expect(response).to have_http_status(404)
-      expect(response.json['errors'].size).to eq(1)
-      expect(response.json['errors'][0]['message']).to eq("User could not be found.")
+      expect(response.parsed_body['errors'].size).to eq(1)
+      expect(response.parsed_body['errors'][0]['message']).to eq("User could not be found.")
     end
 
     it 'filters non-public posts' do
@@ -95,8 +95,8 @@ RSpec.describe Api::V1::UsersController do
       create(:post, privacy: :private, user: user)
       get :posts, params: { id: user.id }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].size).to eq(1)
-      expect(response.json['results'][0]['id']).to eq(public_post.id)
+      expect(response.parsed_body['results'].size).to eq(1)
+      expect(response.parsed_body['results'][0]['id']).to eq(public_post.id)
     end
 
     it 'returns only the correct posts', :show_in_doc do
@@ -106,24 +106,24 @@ RSpec.describe Api::V1::UsersController do
       create(:post, user: create(:user))
       get :posts, params: { id: user.id }
       expect(response).to have_http_status(200)
-      expect(response.json['results'].size).to eq(1)
-      expect(response.json['results'][0]['id']).to eq(user_post.id)
-      expect(response.json['results'][0]['board']['id']).to eq(user_post.board_id)
-      expect(response.json['results'][0]['section']['id']).to eq(user_post.section_id)
+      expect(response.parsed_body['results'].size).to eq(1)
+      expect(response.parsed_body['results'][0]['id']).to eq(user_post.id)
+      expect(response.parsed_body['results'][0]['board']['id']).to eq(user_post.board_id)
+      expect(response.parsed_body['results'][0]['section']['id']).to eq(user_post.section_id)
     end
 
     it 'paginates results' do
       user = create(:user)
       create_list(:post, 26, user: user)
       get :posts, params: { id: user.id }
-      expect(response.json['results'].size).to eq(25)
+      expect(response.parsed_body['results'].size).to eq(25)
     end
 
     it 'paginates results on additional pages' do
       user = create(:user)
       create_list(:post, 27, user: user)
       get :posts, params: { id: user.id, page: 2 }
-      expect(response.json['results'].size).to eq(2)
+      expect(response.parsed_body['results'].size).to eq(2)
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -20,20 +20,20 @@ RSpec.describe ApplicationController do
       login_as(create(:user, timezone: different_zone))
 
       get :index
-      expect(response.json['zone']).to eq(different_zone)
+      expect(response.parsed_body['zone']).to eq(different_zone)
     end
 
     it "succeeds when logged out" do
       current_zone = Time.zone.name
       get :index
-      expect(response.json['zone']).to eq(current_zone)
+      expect(response.parsed_body['zone']).to eq(current_zone)
     end
 
     it "succeeds when logged in user has no zone set" do
       current_zone = Time.zone.name
       login_as(create(:user, timezone: nil))
       get :index
-      expect(response.json['zone']).to eq(current_zone)
+      expect(response.parsed_body['zone']).to eq(current_zone)
     end
   end
 
@@ -445,7 +445,7 @@ RSpec.describe ApplicationController do
       user = create(:user)
       login_as(user)
       get :index
-      expect(response.json['logged_in']).to be(true)
+      expect(response.parsed_body['logged_in']).to be(true)
     end
 
     it "logs out suspended" do
@@ -454,7 +454,7 @@ RSpec.describe ApplicationController do
       user.role_id = Permissible::SUSPENDED
       user.save!
       get :index
-      expect(response.json['logged_in']).to eq(false)
+      expect(response.parsed_body['logged_in']).to eq(false)
     end
 
     it "logs out deleted" do
@@ -463,7 +463,7 @@ RSpec.describe ApplicationController do
       user.deleted = true
       user.save!
       get :index
-      expect(response.json['logged_in']).to eq(false)
+      expect(response.parsed_body['logged_in']).to eq(false)
     end
   end
 
@@ -475,7 +475,7 @@ RSpec.describe ApplicationController do
       cookies.signed[:user_id] = user.id
 
       get :index
-      expect(response.json['zone']).to eq(different_zone)
+      expect(response.parsed_body['zone']).to eq(different_zone)
     end
   end
 

--- a/spec/controllers/bugs_controller_spec.rb
+++ b/spec/controllers/bugs_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BugsController do
       expect(ExceptionNotifier).to receive(:notify_exception).with(an_instance_of(Icon::UploadError), data: params)
       post :create, params: data
       expect(response.status).to eq(200)
-      expect(response.json).to eq({})
+      expect(response.parsed_body).to eq({})
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -207,15 +207,6 @@ end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
-# Monkey patches the controller response objects to return JSON
-module ActionDispatch # rubocop:disable Style/ClassAndModuleChildren
-  class TestResponse
-    def json
-      @json ||= JSON.parse(self.body)
-    end
-  end
-end
-
 require 'webmock/rspec'
 WebMock.disable_net_connect!(
   allow_localhost: true,


### PR DESCRIPTION
As of Rails 5.0, parsed_body exists and handles the content type stuff here! No need to explicitly `.json`.