### PR TITLE
Enable safer 7.1 configs

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -13,7 +13,7 @@
 # to manually require files that are managed by the autoloader, which you shouldn't do anyway.
 # This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
 # of the bootsnap cache if you use it.
-# Rails.application.config.add_autoload_paths_to_load_path = false
+Rails.application.config.add_autoload_paths_to_load_path = false
 
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
@@ -27,7 +27,7 @@ Rails.application.config.action_dispatch.default_headers = {
 
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm. Important: If you have
 # data encrypted with previous Rails versions, there are two scenarios to consider:
@@ -70,18 +70,18 @@ Rails.application.config.active_record.allow_deprecated_singular_associations_na
 # replicas will not be able to deserialize `BigDecimal` arguments from this
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
-# Rails.application.config.active_job.use_big_decimal_serializer = true
+Rails.application.config.active_job.use_big_decimal_serializer = true
 
 # Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
 # `write` are given an invalid `expires_at` or `expires_in` time.
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 # Specify whether Query Logs will format tags using the SQLCommenter format
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
 # Options are `:legacy` and `:sqlcommenter`.
-# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
 # instances.
@@ -127,9 +127,9 @@ Rails.application.config.active_record.allow_deprecated_singular_associations_na
 # `config.load_defaults 7.1` does not set this value for environments other than
 # development and test.
 #
-# if Rails.env.local?
-#   Rails.application.config.log_file_size = 100 * 1024 * 1024
-# end
+if Rails.env.local?
+  Rails.application.config.log_file_size = 100 * 1024 * 1024
+end
 
 # Enable raising on assignment to attr_readonly attributes. The previous
 # behavior would allow assignment but silently not persist changes to the
@@ -143,7 +143,7 @@ Rails.application.config.active_record.belongs_to_required_validates_foreign_key
 
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
-# Rails.application.config.precompile_filter_parameters = true
+Rails.application.config.precompile_filter_parameters = true
 
 # Enable before_committed! callbacks on all enrolled records in a transaction.
 # The previous behavior was to only run the callbacks on the first copy of a record
@@ -197,7 +197,7 @@ Rails.application.config.active_record.generate_secure_token_on = :initialize
 #
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #
-# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 # Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
 # platform.
@@ -207,11 +207,11 @@ Rails.application.config.active_record.generate_secure_token_on = :initialize
 #
 # In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
 #
-# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests
-# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+Rails.application.config.action_dispatch.debug_exception_log_level = :error
 
 # Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5
 # parsers.
@@ -220,4 +220,4 @@ Rails.application.config.active_record.generate_secure_token_on = :initialize
 #
 # In previous versions of Rails, these test helpers always used an HTML4 parser.
 #
-# Rails.application.config.dom_testing_default_html_version = :html5
+Rails.application.config.dom_testing_default_html_version = :html5

--- a/spec/controllers/posts/show_spec.rb
+++ b/spec/controllers/posts/show_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe PostsController, 'GET show' do
       allow(Post).to receive(:find_by_id).with(post.id.to_s).and_return(post)
 
       allow(post).to receive(:build_new_reply_for).and_call_original
-      expect(post).to receive(:build_new_reply_for).with(user, {})
+      expect(post).to receive(:build_new_reply_for).with(user, an_instance_of(ActionController::Parameters).and(be_empty))
       expect(controller).to receive(:setup_layout_gon).and_call_original
 
       get :show, params: { id: post.id }
@@ -328,7 +328,7 @@ RSpec.describe PostsController, 'GET show' do
       allow(Post).to receive(:find_by_id).with(post.id.to_s).and_return(post)
 
       allow(post).to receive(:build_new_reply_for).and_call_original
-      expect(post).to receive(:build_new_reply_for).with(user, {}).and_call_original
+      expect(post).to receive(:build_new_reply_for).with(user, an_instance_of(ActionController::Parameters).and(be_empty)).and_call_original
 
       get :show, params: { id: post.id }
       expect(response).to have_http_status(200)


### PR DESCRIPTION
TODO:

- A while after the rotator deploy for 7.0, switch on `Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256` and then `Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256`
- After we're sure 7.1 will stay around, switch on `Rails.application.config.active_support.message_serializer = :json_allow_marshal`
- After we're sure 7.1 will stay around, switch `config.active_support.cache_format_version = 7.1` (not `7.0`)
- After we're sure 7.1 will stay around, switch on `Rails.application.config.active_support.use_message_serializer_for_metadata = true`
- After we're sure 7.1 will stay around, switch on `Rails.application.config.active_record.marshalling_format_version = 7.1`
- Check if audited uses the default YAML column serializer, and if not, enable `Rails.application.config.active_record.default_column_serializer = nil`