### PR TITLE
Use bash via /usr/bin/env instead of hardcoding /bin/bash

### DIFF
--- a/bin-docker/backstop
+++ b/bin-docker/backstop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin-docker/bundle
+++ b/bin-docker/bundle
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web bundle "$@"

--- a/bin-docker/psql
+++ b/bin-docker/psql
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm postgres psql "$@"

--- a/bin-docker/rails
+++ b/bin-docker/rails
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web bin/rails $@

--- a/bin-docker/rake
+++ b/bin-docker/rake
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web rake "$@"

--- a/bin-docker/record_examples
+++ b/bin-docker/record_examples
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm -e "APIPIE_RECORD=examples" web bundle exec rspec spec/controllers/api

--- a/bin-docker/rspec
+++ b/bin-docker/rspec
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web bundle exec rspec "$@"

--- a/bin-docker/runner
+++ b/bin-docker/runner
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web "$@"


### PR DESCRIPTION
This fixes running scripts for systems where bash is not installed in /bin