### PR TITLE
Add post subcontinuities to post lists

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -227,6 +227,15 @@ table { width: 100%; }
 
 td, .table-list li { font-size: $font_size_small; }
 
+.post-section { display: none; }
+@media (max-width: 600px) {
+  .post-section {
+    display: inline;
+    font-size: $font_size_mini;
+    line-height: $font_size_mini;
+  }
+}
+
 /* Subs and subbers */
 .sub {
   padding: 10px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,8 @@ class ApplicationController < ActionController::Base
         posts.*,
         max(boards.name) as board_name,
         max(users.username) as last_user_name,
-        bool_or(users.deleted) as last_user_deleted
+        bool_or(users.deleted) as last_user_deleted,
+        max(board_sections.name) as section_name
         #{select}
       SQL
     else
@@ -118,7 +119,8 @@ class ApplicationController < ActionController::Base
         posts.*,
         boards.name as board_name,
         users.username as last_user_name,
-        users.deleted as last_user_deleted
+        users.deleted as last_user_deleted,
+        board_sections.name as section_name
         #{select}
       SQL
     end
@@ -126,6 +128,7 @@ class ApplicationController < ActionController::Base
     relation
       .select(select)
       .joins(:board)
+      .left_joins(:section)
       .joins(:last_user)
       .includes(:authors)
       .with_has_content_warnings

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -41,7 +41,11 @@
             - (total_pages - 2).upto(total_pages) do |index|
               = link_to index, post_path(post, page: index)
   - unless local_assigns[:hide_continuity]
-    %td.post-board.vtop{class: klass}= link_to post.board_name, anchored_continuity_path(post)
+    %td.post-board.vtop{class: klass}
+      = link_to anchored_continuity_path(post), title: post.section_name do
+        = post.board_name
+        - if post.section_name.present?
+          %span.post-section= post.section_name
   %td.post-authors.vtop{class: klass}= author_links(post)
   %td.width-70.post-replies.vtop{class: klass}= link_to replies_count, stats_post_path(post)
   - if logged_in? && local_assigns[:show_unread_count]


### PR DESCRIPTION
On narrow screens this shows up as small text; on desktop it shows up on
hover (based on screen width).