### PR TITLE
Simplify match_hash matcher

### DIFF
--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1093,7 +1093,7 @@ RSpec.describe Post do
         {
           id: post.id,
           subject: post.subject,
-          description: nil,
+          description: "",
           authors: post.joined_authors,
           board: post.board,
           section: nil,


### PR DESCRIPTION
Array sort often doesn't sort the same way as ordered, so we skip that.
Additionally, we only convert when we need to + can, and otherwise use
values_match? (this should hopefully allow other RSpec matchers to
combine).