### PR TITLE
Fix fixture_path deprecation in Rails 7.1

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,7 +28,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec', 'fixtures')
+  # config.fixture_paths = [Rails.root.join('spec', 'fixtures')]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
fixture_paths is the recommended value now, but we're also not using
fixtures, so I commented it out