### PR TITLE
Fix character#edit 'nickname' field label for NPCs

### DIFF
--- a/app/assets/javascripts/characters/editor.js
+++ b/app/assets/javascripts/characters/editor.js
@@ -220,4 +220,9 @@ function updateIcon(id) {
 
 function disableNPCBoxes(disable) {
   $("#character_screenname, #character_template_id, #new_template, #character_template_attributes_name, #character_cluster").prop("disabled", disable);
+  if (disable) {
+    $("label[for='character_nickname']").text("Original post");
+  } else {
+    $("label[for='character_nickname']").text("Nickname");
+  }
 }


### PR DESCRIPTION
Being used as 'Original post', not 'Nickname', so replace the label