### PR TITLE
Set auth token more correctly, blank session on invalid API requests

### DIFF
--- a/app/concerns/authentication/api.rb
+++ b/app/concerns/authentication/api.rb
@@ -36,10 +36,12 @@ module Authentication::Api
       ActiveSupport::HashWithIndifferentAccess.new(body)
     rescue JWT::ExpiredSignature
       error = { message: "Authorization token has expired." }
+      session[:api_token] = nil
       render json: { errors: [error] }, status: :unauthorized
       {}
     rescue JWT::DecodeError
       error = { message: "Authorization token is not valid." }
+      session[:api_token] = nil
       render json: { errors: [error] }, status: :unprocessable_entity
       {}
     end

--- a/app/concerns/authentication/web.rb
+++ b/app/concerns/authentication/web.rb
@@ -38,17 +38,22 @@ module Authentication::Web
     end
 
     def set_user
-      @current_user ||= User.find_by_id(session[:user_id])
-      return unless @current_user
+      return @current_user if @current_user
+      @current_user = User.find_by_id(session[:user_id])
       set_user_token
     end
 
     def set_user_token
+      unless @current_user
+        session[:api_token] = nil
+        return
+      end
+
       expiration = session[:api_token].try(:[], "expires").to_i
       session[:api_token] = nil if Time.zone.now.to_i > expiration
       session[:api_token] ||= {
-        value: Authentication.generate_api_token(@current_user),
-        expires: Authentication::EXPIRY.from_now.to_i,
+        "value" => Authentication.generate_api_token(@current_user),
+        "expires" => Authentication::EXPIRY.from_now.to_i,
       }
     end
   end

--- a/app/concerns/authentication/web.rb
+++ b/app/concerns/authentication/web.rb
@@ -52,7 +52,7 @@ module Authentication::Web
       expiration = session[:api_token].try(:[], "expires").to_i
       session[:api_token] = nil if Time.zone.now.to_i > expiration
       session[:api_token] ||= {
-        "value" => Authentication.generate_api_token(@current_user),
+        "value"   => Authentication.generate_api_token(@current_user),
         "expires" => Authentication::EXPIRY.from_now.to_i,
       }
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,8 +17,8 @@ class SessionsController < ApplicationController
       flash[:success] = "You are now logged in as #{user.username}. Welcome back!"
       session[:user_id] = user.id
       session[:api_token] = {
-        value: auth.api_token,
-        expires: Authentication::EXPIRY.from_now.to_i,
+        "value" => auth.api_token,
+        "expires" => Authentication::EXPIRY.from_now.to_i,
       }
       cookies.permanent.signed[:user_id] = cookie_hash(user.id) if params[:remember_me].present?
       @current_user = user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,7 @@ class SessionsController < ApplicationController
       flash[:success] = "You are now logged in as #{user.username}. Welcome back!"
       session[:user_id] = user.id
       session[:api_token] = {
-        "value" => auth.api_token,
+        "value"   => auth.api_token,
         "expires" => Authentication::EXPIRY.from_now.to_i,
       }
       cookies.permanent.signed[:user_id] = cookie_hash(user.id) if params[:remember_me].present?


### PR DESCRIPTION
Previously the set_auth_token method was called every time we referenced current_user

Additionally, session[:api_token] is accessed by set_login_gon and similar, but using string keys - if the user didn't have an auth token before, and we generate it on this request, the gon value would be nil incorrectly.

Now that we blank the session on invalid API requests, users can also reload the page to get a new API token when an invalid request is sent. This should help get out of bad states more easily!