### PR TITLE
Split character nicknames from aliases

### DIFF
--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -111,15 +111,19 @@
       %tr
         %th.table-title{colspan: 2} Info
     %tbody
-      - nicknames = ([@character.nickname] + @character.aliases.ordered.pluck(:name)).compact
-      - if nicknames.present?
+      - if @character.nickname.present?
         %tr
           %th.sub.vtop.width-150
             - if @character.npc?
-              Original post(s)
+              Original post
             - else
-              Nickname(s)
-          %td.character-template-nickname{class: cycle('even', 'odd')}= nicknames.join(", ")
+              Nickname
+          %td.character-nickname{class: cycle('even', 'odd')}= @character.nickname
+      - aliases = @character.aliases.ordered.pluck(:name)
+      - if aliases.present?
+        %tr
+          %th.sub.vtop.width-150 Aliases
+          %td.character-aliases{class: cycle('even', 'odd')}= aliases.join(", ")
       - if @character.template
         %tr
           %th.sub.vtop.width-150 Template

--- a/spec/system/characters/edit_spec.rb
+++ b/spec/system/characters/edit_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Editing a character" do
     end
     expect(page).to have_text(/MyChar\s+\(NPC\)/)
     expect(page).to have_text('Example facecast')
-    expect(page).to have_text(/Original post\(s\).*Thread/)
+    expect(page).to have_text(/Original post.*Thread/)
 
     # turn NPC into non-NPC
     visit edit_character_path(character)
@@ -77,6 +77,6 @@ RSpec.describe "Editing a character" do
     end
     expect(page).to have_no_text('(NPC)')
     expect(page).to have_text('example_screenname')
-    expect(page).to have_text(/Nickname\(s\).*Thread/)
+    expect(page).to have_text(/Nickname.*Thread/)
   end
 end

--- a/spec/system/characters/show_spec.rb
+++ b/spec/system/characters/show_spec.rb
@@ -227,7 +227,10 @@ RSpec.describe "Viewing a character" do
     within('.character-right-content-box') do
       expect(page).to have_selector('th', text: 'Nickname')
       within(row_for('Nickname')) do
-        expect(page).to have_selector('td', exact_text: 'Char, Alias Person')
+        expect(page).to have_selector('td', exact_text: 'Char')
+      end
+      within(row_for('Aliases')) do
+        expect(page).to have_selector('td', exact_text: 'Alias Person')
       end
 
       expect(page).to have_selector('th', text: 'Template')

--- a/spec/system/posts/new_spec.rb
+++ b/spec/system/posts/new_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Creating posts" do
     end
 
     expect(page).to have_text(/Adam\s+\(NPC\)/)
-    expect(page).to have_text(/Original post\(s\).*test subject/)
+    expect(page).to have_text(/Original post.*test subject/)
   end
 
   scenario "User creates a post with an existing NPC", :js do

--- a/spec/system/replies/new_spec.rb
+++ b/spec/system/replies/new_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Creating replies" do
     end
 
     expect(page).to have_text(/Jade\s+\(NPC\)/)
-    expect(page).to have_text(/Original post\(s\).*Sample post/)
+    expect(page).to have_text(/Original post.*Sample post/)
     expect(page).to have_text(/Setting.*Settingsverse/)
   end
 


### PR DESCRIPTION
Nicknames aren't used as often nowadays, and the UI is a bit strange after the NPC "Original posts" hack. Splitting it here to make things easier + clearer.

Also requested by Red.