### PR TITLE
Fix and document backstop

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To perform a test:
 
 ```bash
 # you may wish to recreate + reseed your database for consistent images:
-# bin-docker/rails db:drop db:setup
+# bin-docker/rails db:reset
 
 # set the layout you want to validate
 export LAYOUT=starrylight

--- a/README.md
+++ b/README.md
@@ -138,6 +138,38 @@ Tools we do not currently use but are interested in evaluating:
 * [Reek](https://github.com/troessner/reek) and [Flog](https://github.com/seattlerb/flog) if they're not already included by CodeClimate or other gems (Marri's brain thinks they might be, the way flay is in duplication, but isn't citing its sources)
 * [Reek's brother and sister gems](https://github.com/troessner/reek#brothers-and-sisters)
 
+### Backstop - UI validation
+
+We use [BackstopJS](https://github.com/garris/BackstopJS) to run regression tests on the UI + CSS.
+
+Before each test, we automatically run `script/before_backstop.rb` to set up a consistent environment.
+To perform a test:
+
+```bash
+# you may wish to recreate + reseed your database for consistent images:
+# bin-docker/rails db:drop db:setup
+
+# set the layout you want to validate
+export LAYOUT=starrylight
+
+# switch to the branch you want to use as a reference
+git switch main
+# create reference images and save them to backstop/
+bin-docker/backstop reference $LAYOUT
+
+# switch to the branch you want to test
+git switch feature/update-css
+# validate the layout against the reference images
+bin-docker/backstop test $LAYOUT
+
+# see a list of other commands you can run:
+bin-docker/backstop --help
+# view a report in your browser:
+open backstop/reports/$LAYOUT/index.html
+# promote the images to reference images if the changes are intentional:
+bin-docker/backstop approve $LAYOUT
+```
+
 ### Attribution
 
 We make use of the [famfamfam silk](http://www.famfamfam.com/lab/icons/silk/) pack of icons, which is licensed under a Creative Commons Attribution license, including some icons that have been modified from the originals.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
   def pretty_time(time, format: nil)
     return unless time
     content_tag(:time, datetime: time.utc.iso8601, title: time.utc.strftime("%Y-%m-%d %H:%M %Z")) do
-      time.strftime(format || current_user.try(:time_display) || TIME_FORMAT)
+      time.in_time_zone.strftime(format || current_user.try(:time_display) || TIME_FORMAT)
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,6 +85,9 @@ load Rails.root.join('db', 'seeds', 'post.rb')
 puts "Creating replies..."
 load Rails.root.join('db', 'seeds', 'reply.rb')
 
+puts "Queuing flat post generation (will not update until jobs are run)"
+FlatPost.regenerate_all
+
 puts "Creating tags..."
 load Rails.root.join('db', 'seeds', 'tag.rb')
 

--- a/db/seeds/post.rb
+++ b/db/seeds/post.rb
@@ -591,6 +591,3 @@ Post::View.create!([
   { post_id: 32, user_id: 3, read_at: "2015-07-23 00:57:00" },
   { post_id: 33, user_id: 3, read_at: "2019-08-18 21:22:42" },
 ])
-
-puts "Queuing flat post generation (will not update until jobs are run)"
-FlatPost.regenerate_all

--- a/docker-compose-backstop.yml
+++ b/docker-compose-backstop.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   backstop:
-    image: backstopjs/backstopjs
+    image: backstopjs/backstopjs:5.4.4
     working_dir: /src
     volumes:
       - "./backstop/:/src"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     environment:
       <<: *env
       BIND_HOST: 0.0.0.0
+      # allow accessing the server from backstop
+      RAILS_DEVELOPMENT_HOSTS: web:3000
   worker:
     <<: *svc
     command: bundle exec rake resque:work


### PR DESCRIPTION
This includes:

* Pinning the backstop version (newer versions use a newer version of puppeteer that seems to have removed waitFor in favor of more specific methods, which I'm avoiding changing for now)
* Adding clear steps on how to run backstop in the README
* Allowing requests from backstop's Docker container with the [`ActionDispatch::HostAuthorization`](https://edgeguides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization) middleware
* A fix to the default format for pretty_time (it previously didn't always use in_time_zone and at some point boards#index has regressed to using the wrong timezone for its update time? post lists seem fine still...)
* Triggering FlatPost.regenerate_all after creating the replies in seeds

I haven't yet regenerated images here - in particular I'm seeing a lot of small differences due to things like checkbox rendering and tiny padding differences, which I think might be due to my machine not being Linux, and then some larger changes that are expected (like changed buttons / labels over the place).