### PR TITLE
Upgrade backstop to 6.3.3

### DIFF
--- a/backstop/engine_scripts/puppet/clickAndHoverHelper.js
+++ b/backstop/engine_scripts/puppet/clickAndHoverHelper.js
@@ -3,33 +3,33 @@ module.exports = async (page, givenScenario) => {
     hoverSelectors: [],
     clickSelectors: [],
     keyPressSelectors: [],
-    // postInteractionWait: selector [str] | ms [int]
+    // postInteractionWait: ms [int]
     postInteractionWait: null,
     scrollToSelector: null,
   };
   const config = Object.assign(defaults, givenScenario);
 
   for (const keyPressSelectorItem of config.keyPressSelectors) {
-    await page.waitFor(keyPressSelectorItem.selector);
+    await page.waitForSelector(keyPressSelectorItem.selector);
     await page.type(keyPressSelectorItem.selector, keyPressSelectorItem.keyPress);
   }
 
   for (const hoverSelectorItem of config.hoverSelectors) {
-    await page.waitFor(hoverSelectorItem);
+    await page.waitForSelector(hoverSelectorItem);
     await page.hover(hoverSelectorItem);
   }
 
   for (const clickSelectorItem of config.clickSelectors) {
-    await page.waitFor(clickSelectorItem);
+    await page.waitForSelector(clickSelectorItem);
     await page.click(clickSelectorItem);
   }
 
   if (config.postInteractionWait) {
-    await page.waitFor(config.postInteractionWait);
+    await page.waitForTimeout(config.postInteractionWait);
   }
 
   if (config.scrollToSelector) {
-    await page.waitFor(config.scrollToSelector);
+    await page.waitForSelector(config.scrollToSelector);
     await page.evaluate(scrollToSelector => {
       document.querySelector(scrollToSelector).scrollIntoView();
     }, config.scrollToSelector);

--- a/bin-docker/backstop
+++ b/bin-docker/backstop
@@ -3,11 +3,12 @@
 set -e
 
 NUM_CONTAINERS=$(docker compose ps | wc -l)
+DOCKER_COMPOSE="docker compose -f docker-compose.yml -f docker-compose-backstop.yml"
 
 if [ "$1" == 'test' ] || [ "$1" == 'reference' ] && [ "$2" != 'logged_out' ]; then
-  docker compose run --rm web bin/rails runner script/before_backstop.rb $2
+  $DOCKER_COMPOSE run --rm web bin/rails runner script/before_backstop.rb "$2"
 fi
-docker compose -f docker-compose.yml -f docker-compose-backstop.yml run --rm backstop $1 --config $2
+$DOCKER_COMPOSE run --rm backstop --config "$2" "$1" "${@:3}"
 
 if [ $NUM_CONTAINERS == 2 ]; then
 	docker compose down

--- a/docker-compose-backstop.yml
+++ b/docker-compose-backstop.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   backstop:
-    image: backstopjs/backstopjs:5.4.4
+    image: backstopjs/backstopjs:6.3.3
     working_dir: /src
     volumes:
       - "./backstop/:/src"


### PR DESCRIPTION
There seem to be issues generating some images after this change (missing `#content` selectors, etc) so I'll leave this in draft until we have a chance to get to it.