### PR TITLE
Disable autoresize and wordcount plugins for TinyMCE

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -10,7 +10,7 @@ function tinyMCEConfig(selector) {
   return {
     // integration configs
     selector: selector,
-    plugins: ["wordcount", "image", "link", "autoresize"],
+    plugins: ["image", "link"],
     cache_suffix: '?v=6.8.2',
     // interface configs
     menubar: false, // disable "File", "Edit", etc


### PR DESCRIPTION
New plugin versions aren't compatible but are cached in Cloudfront, and it isn't varying based on query string so we can't cache-bust with a cache suffix.

For more details, see
https://discord.com/channels/521407923629457428/521411396613701662/1199374647699972157