### PR TITLE
Fix ETag invalidation for posts#owed when reading a post

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,13 +140,13 @@ class ApplicationController < ActionController::Base
     @opened_ids ||= post_views.pluck(:post_id)
 
     opened_posts = post_views.where(post_id: posts.map(&:id)).select([:post_id, :read_at])
-    unread_views = opened_posts.select do |view|
+    @unread_views = opened_posts.select do |view|
       post = posts.detect { |p| p.id == view.post_id }
       post && view.read_at < post.tagged_at
     end
 
     @unread_ids ||= []
-    @unread_ids += unread_views.map(&:post_id)
+    @unread_ids += @unread_views.map(&:post_id)
 
     return unless with_unread
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -40,7 +40,7 @@ class PostsController < WritableController
     @posts = posts_from_relation(@posts.ordered)
     @page_title = 'Replies Owed'
     @page_title = "[#{@posts.count}] Replies Owed" if @posts.count > 0
-    fresh_when(etag: @posts, public: false)
+    fresh_when(etag: [@posts, @unread_views], public: false)
   end
 
   def unread

--- a/app/models/post/view.rb
+++ b/app/models/post/view.rb
@@ -6,6 +6,8 @@ class Post::View < ApplicationRecord
 
   after_create :mark_favorite_read
 
+  alias_attribute :updated_at, :read_at # used to support use in fresh_when
+
   private
 
   def mark_favorite_read


### PR DESCRIPTION
`@posts` isn't updated when users read posts, so we need to include the unread_views entry for users' browsers to correctly update the page's arrow colors when they read posts.