### PR TITLE
Various linting work

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -26,31 +26,6 @@ linters:
   LineLength:
     enabled: false
 
-  RuboCop:
-    ignored_cops:
-      - Lint/BlockAlignment
-      - Lint/EndAlignment
-      - Lint/Void
-      - Layout/ArgumentAlignment
-      - Layout/CaseIndentation
-      - Layout/ElseAlignment
-      - Layout/EndOfLine
-      - Layout/HashAlignment
-      - Layout/IndentationWidth
-      - Layout/LeadingCommentSpace # added
-      - Layout/LineLength
-      - Layout/ParameterAlignment
-      - Layout/TrailingEmptyLines
-      - Layout/TrailingWhitespace
-      - Metrics/BlockLength
-      - Metrics/BlockNesting
-      - Naming/FileName
-      - Rails/OutputSafety # added
-      - Style/FrozenStringLiteralComment
-      - Style/IfUnlessModifier
-      - Style/Next
-      - Style/WhileUntilModifier
-
   SpaceBeforeScript:
     enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -730,6 +730,9 @@ Capybara/NegationMatcher: # new in 2.14
   Enabled: true
   EnforcedStyle: have_no
 
+Capybara/RedundantWithinFind: # new in 2.20
+  Enabled: true
+
 Capybara/RSpec/HaveSelector: # new in 2.19
   Enabled: false
 
@@ -752,6 +755,10 @@ FactoryBot/AssociationStyle: # new in 2.23
 
 FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: true
+
+FactoryBot/ExcessiveCreateList: # new in 2.25
+  Enabled: true
+  MaxAmount: 27 # to allow pagination tests
 
 FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
   Enabled: true

--- a/app/views/.rubocop.yml
+++ b/app/views/.rubocop.yml
@@ -1,0 +1,19 @@
+inherit_from: ../../.rubocop.yml
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Rails/OutputSafety:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/RedundantConstantBase:
+  Enabled: false # Template resolves to ActionView::Template in views
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma

--- a/app/views/galleries/_add_new.haml
+++ b/app/views/galleries/_add_new.haml
@@ -30,7 +30,9 @@
         - s3_key = @icons[i].try(:[], :s3_key)
         - url = @icons[i].try(:[], :url)
         - keyword = @icons[i].try(:[], :keyword)
-        - purl, pkey = url, keyword if s3_key.present?
+        - if s3_key.present?
+          - purl = url
+          - pkey = keyword
         %tr.icon-row{data: { index: i }}
           - empty_gif = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
           %td.width-15{class: klass, style: 'padding: 0px;'}= icon_mem_tag purl || empty_gif, pkey || '', class: 'vmid preview-icon'

--- a/app/views/index_posts/edit.haml
+++ b/app/views/index_posts/edit.haml
@@ -5,7 +5,6 @@
   &raquo;
   = link_to @index_post.post.subject, post_path(@index_post.post)
 
-
 = form_for @index_post do |f|
   %table.form-table
     %thead

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -21,7 +21,7 @@
           alt: 'Three stars, colored green, purple and blue',
           width: '48',
           height: '48',
-        }) # rubocop:disable Style/TrailingCommaInArguments
+        })
       %meta{property: 'og:image', content: image_hash[:src]}
       - [:type, :alt, :width, :height].each do |prop|
         - if image_hash.key?(prop)

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -34,7 +34,6 @@
       = submit_tag (post.new_record? ? 'Post' : 'Save'), class: 'button', id: 'submit_button', data: { disable_with: 'Saving...' }
       = submit_tag "Preview", class: 'button', id: 'preview_button', name: 'button_preview', data: { disable_with: 'Previewing...' }
 
-
   .subber Metadata
   .even
     = f.label :board_id, 'Continuity:'
@@ -57,7 +56,6 @@
         = safe_join(authors.map { |author| user_link(author) }, ', ')
       - else
         = user_link(current_user)
-
 
     %div{title: 'Invite users to be authors in this post. Once they post, they will be removed from this section and moved to a Current Authors section. Invited authors will have this post show on their Replies Owed page, even if they have not yet joined the post. If the post is locked, invited users will have permission to reply. This field will not override privacy settings. You are automatically added as an author when you create a new post.'}
       = f.label :unjoined_author_ids, 'Invite coauthors:'

--- a/app/views/writable/_history.haml
+++ b/app/views/writable/_history.haml
@@ -59,7 +59,7 @@
             %b= privacy_state(Post.privacies.key(audit.audited_changes['privacy'][0]))
             to
             %b= privacy_state(cur.privacy)
-      - if audit.action != 'destroy' && (audit.action == 'create' || (audit.audited_changes.keys & %w(character_alias_id character_id content description icon_id subject)).present?)
+      - if audit.action != 'destroy' && (audit.action == 'create' || audit.audited_changes.keys.intersect?(%w(character_alias_id character_id content description icon_id subject)))
         %tr
           %th.sub.vtop Content
           %td{class: cycle('even', 'odd')}


### PR DESCRIPTION
- Configure some cops that apparently got missed when they were added to the relevant rubocop gems
- Clean up some haml lints from, most likely, that not being checked when we enabled the cops on rubocop
- Make a specific rubocop file for app/views to work with haml-lint's config file, rather than a constantly out of date list of ignored cops