### PR TITLE
Get haml-lint rubocop to chill

### DIFF
--- a/app/views/.rubocop.yml
+++ b/app/views/.rubocop.yml
@@ -3,6 +3,12 @@ inherit_from: ../../.rubocop.yml
 Layout/ArgumentAlignment:
   Enabled: false
 
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
 Rails/OutputSafety:
   Enabled: false
 


### PR DESCRIPTION
I don't know why these passed locally but are having trouble on PRs but there's a simple solution