### PR TITLE
Bump bundler to 2.5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
   && apt install -y curl chromium \
   && apt-get clean
 
-ARG bundler_version=2.3.25
+ARG bundler_version=2.5.6
 
 RUN gem install bundler -v $bundler_version
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -618,4 +618,4 @@ RUBY VERSION
    ruby 3.3.1p55
 
 BUNDLED WITH
-   2.3.25
+   2.5.6


### PR DESCRIPTION
Heroku supports different bundler versions based on the Gemfile - latest available version is 2.5.6

https://devcenter.heroku.com/articles/ruby-support#libraries