### PR TITLE
Fix health-cmd for rspec postgres

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,13 +24,15 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: glowfic_test
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: glowfic_test
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
         # reference: https://docs.github.com/en/actions/guides/creating-redis-service-containers#running-jobs-in-containers
         image: redis:6.2
-        ports:
-        - 6379:6379
+        ports: ["6379:6379"]
         options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     env:


### PR DESCRIPTION
Previously reported 'role "root" does not exist', was using the wrong credentials

Doesn't seem to have any meaningful impact though? Not sure what it's actually using this health command for, given that there's only 5 retries (maybe if it never succeeds then it's not relevant, but if it succeeds then fails then it uses it to kill the container...?)