### PR TITLE
Use pagination more to avoid large loads

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -56,6 +56,7 @@ class BoardsController < ApplicationController
   def show
     @page_title = @board.name
     @board_sections = @board.board_sections.ordered
+    @board_sections = @board_sections.paginate(per_page: 25, page: params[:page])
     board_posts = @board.posts.where(section_id: nil)
     if @board.ordered?
       board_posts = board_posts.ordered_in_section

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -65,9 +65,10 @@ class GalleriesController < UploadingController
       @page_title = @gallery.name + ' (Gallery)'
       @meta_og = og_data
     end
-    icons = @gallery ? @gallery.icons : @user.galleryless_icons
-    @times_used, @posts_used = Icon.times_used(icons, current_user) if page_view == 'list'
-    render :show, locals: { icons: icons }
+    @icons = @gallery ? @gallery.icons : @user.galleryless_icons
+    @icons = @icons.paginate(per_page: 100, page: params[:page])
+    @times_used, @posts_used = Icon.times_used(@icons, current_user) if page_view == 'list'
+    render :show, locals: { icons: @icons }
   end
 
   def edit

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -18,6 +18,8 @@ class GalleriesController < UploadingController
     else
       @user.username + "'s Galleries"
     end
+    @galleries = @user.galleries.ordered_by_name
+    @galleries = @galleries.paginate(per_page: 100, page: params[:page])
     use_javascript('galleries/expander')
     gon.user_id = @user.id
   end

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -55,6 +55,11 @@
         %tr
           %td.continuity-spacer{colspan: 5}
       = render partial: 'posts/list_item', collection: @posts, as: :post, locals: { hide_continuity: true }
+
+    - if @board_sections.methods.include?(:total_pages) && @board_sections.total_pages > 1
+      %tfoot
+        %tr
+          %td= render 'posts/paginator', paginated: @board_sections, no_per: true
 - else
   - if @board.description.present?
     - content_for :post_list_description do

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -35,3 +35,7 @@
       = render partial: 'characters/icon_item', collection: characters, as: :character
       - unless characters.present?
         .centered — No characters yet —
+- if characters.methods.include?(:total_pages) && characters.total_pages > 1
+  %tfoot
+    %tr
+      %td= render 'posts/paginator', paginated: characters

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -74,8 +74,10 @@
       - if (group_chars = @user.characters.non_npcs.where(character_group_id: nil)).exists?
         = render 'group', characters: group_chars, group: nil, skip_grouped_templates: true, page_view: page_view, colspan: colspan
     - elsif @user.characters.exists?
-      = render partial: partial_type, collection: @user.templates.ordered, as: :name
-      - if (templateless = @user.characters.non_npcs.where(template_id: nil)).exists?
+      - templates = @user.templates.ordered
+      - templates.paginate(per_page: 25, page: params[:page]) if templates.count > 50
+      = render partial: partial_type, collection: templates, as: :name
+      - if (templateless = @user.characters.non_npcs.where(template_id: nil)).exists? && (templates.methods.exclude?(:total_pages) || templates.total_pages == params[:page])
         = render partial_type, name: "No Template", characters: templateless.ordered, show_new_character_button: @user.id == current_user&.id
     - else
       %tr

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -6,8 +6,10 @@
 
 - if page_view == 'list'
   - colspan = (character_split == 'none') ? 8 : 7
+  - per_page = 25
 - else
   - colspan = 1
+  - per_page = 50
 %table
   %tr
     %th.table-title{colspan: colspan}
@@ -82,9 +84,9 @@
     - else
       %tr
         %td.centered.padding-5{class: cycle('even', 'odd'), colspan: colspan} — No characters yet —
-  - elsif character_split == 'npcs'
-    - characters = @user.characters.npcs.ordered
-    = render partial_type, name: nil, characters: characters, show_template: false
   - else
-    - characters = @user.characters.non_npcs.includes(:template).ordered
-    = render partial_type, name: nil, characters: characters, show_template: true
+    - characters = @user.characters.ordered
+    - characters = character_split == 'npcs' ? characters.npcs : characters.non_npcs
+    - characters = characters.includes(:template) unless character_split == 'npcs'
+    - characters.paginate(per_page: per_page, page: params[:page]) if characters.count > 100
+    = render partial_type, name: nil, characters: characters, show_template: false

--- a/app/views/galleries/index.haml
+++ b/app/views/galleries/index.haml
@@ -39,4 +39,9 @@
           - if @user.id == current_user.try(:id)
             .clear.centered.icons-remove
               = submit_tag "x Delete selected icons permanently", data: { confirm: "Are you sure? These icons will be gone from the site!" }
-    = render partial: 'galleries/expandable', collection: @user.galleries.with_icon_count.with_gallery_groups.ordered_by_name, as: :gallery
+    = render partial: 'galleries/expandable', collection: @galleries.with_icon_count.with_gallery_groups, as: :gallery
+
+  - if @galleries.methods.include?(:total_pages) && @galleries.total_pages > 1
+    %tfoot
+      %tr
+        %td= render 'posts/paginator', paginated: @galleries, no_per: true

--- a/app/views/galleries/show.haml
+++ b/app/views/galleries/show.haml
@@ -10,3 +10,8 @@
         = link_to "#{@user.username}'s Galleries", user_galleries_path(@user)
     &raquo;
     %b= @gallery ? @gallery.name : 'Galleryless Icons'
+
+  - if icons.methods.include?(:total_pages) && icons.total_pages > 1
+    %tfoot
+      %tr
+        %td{colspan: ((page_view == 'list') ? 5 : 1) }= render 'posts/paginator', paginated: icons, no_per: true

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -259,6 +259,13 @@ RSpec.describe BoardsController do
       expect(assigns(:posts).size).to eq(25)
     end
 
+    it "paginates sections" do
+      create_list(:board_section, 26, board: board)
+      get :show, params: { id: board.id }
+      expect(assigns(:board_sections).size).to eq(25)
+      expect(assigns(:board_sections).total_pages).to eq(2)
+    end
+
     it "orders the posts by tagged_at in unordered boards" do
       Array.new(3) { create(:post, board: board, tagged_at: Time.zone.now + rand(5..30).hours) }
       get :show, params: { id: board.id }

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -57,54 +57,78 @@ RSpec.describe CharactersController do
     context "with render_views" do
       render_views
 
+      let!(:user) { create(:user) }
+      let!(:character) { create(:character, user: user, name: 'ExistingCharacter') }
+      let(:template) { create(:template, user: user) }
+      let(:template_character) { create(:character, template: template, user: user)}
+
       it "successfully renders the page in template group" do
-        character = create(:character)
-        create(:template_character, user: character.user) # character2
+        template_character
         get :index, params: { user_id: character.user_id, character_split: 'template' }
         expect(response.status).to eq(200)
       end
 
       it "successfully renders the page with no group" do
-        character = create(:character)
-        create(:template_character, user: character.user) # character2
+        template_character
         get :index, params: { user_id: character.user_id, character_split: 'none' }
         expect(response.status).to eq(200)
       end
 
       it "skips NPC characters" do
-        character = create(:character, name: 'ExistingCharacter')
         create(:character, user: character.user, npc: true, name: 'NPCCharacter')
         get :index, params: { user_id: character.user_id }
         expect(response.body).to include('ExistingCharacter')
         expect(response.body).not_to include('NPCCharacter')
       end
 
-      it "skips retired characters when specified" do
-        character = create(:character, name: 'ExistingCharacter')
-        create(:character, user: character.user, retired: true, name: 'RetiredCharacter')
-        get :index, params: { user_id: character.user_id, retired: 'false' }
-        expect(response.body).to include('ExistingCharacter')
-        expect(response.body).not_to include('RetiredCharacter')
+      context "successfully paginates" do
+        render_views
+
+        let(:user) { create(:user) }
+
+        context "with template grouping" do
+          let(:templates) do
+            list = create_list(:template, 51, user: user) # rubocop:disable FactoryBot/ExcessiveCreateList
+            Template.where(id: list.map(&:id)).ordered
+          end
+
+          it "in icon view" do
+            get :index, params: { user_id: user.id, character_split: 'template', view: 'icons' }
+            expect(response.body).not_to include(templates.to_ary[26].name)
+          end
+
+          it "in list view" do
+            get :index, params: { user_id: user.id, character_split: 'template', view: 'list' }
+            expect(response.body).not_to include(templates.to_ary[26].name)
+          end
+        end
+
       end
 
-      it "skips retired characters when specified as a default setting" do
-        character = create(:character, name: 'ExistingCharacter')
-        character.user.update!(default_hide_retired_characters: true)
-        create(:character, user: character.user, retired: true, name: 'RetiredCharacter')
-        login_as(character.user)
-        get :index, params: { user_id: character.user_id }
-        expect(response.body).to include('ExistingCharacter')
-        expect(response.body).not_to include('RetiredCharacter')
-      end
+      context "retired" do
+        before(:each) { create(:character, user: user, retired: true, name: 'RetiredCharacter') }
 
-      it "still shows retired characters when default setting is overridden" do
-        character = create(:character, name: 'ExistingCharacter')
-        character.user.update!(default_hide_retired_characters: true)
-        create(:character, user: character.user, retired: true, name: 'RetiredCharacter')
-        login_as(character.user)
-        get :index, params: { user_id: character.user_id, retired: 'true' }
-        expect(response.body).to include('ExistingCharacter')
-        expect(response.body).to include('RetiredCharacter')
+        it "skips retired characters when specified" do
+          get :index, params: { user_id: user.id, retired: 'false' }
+          expect(response.body).to include('ExistingCharacter')
+          expect(response.body).not_to include('RetiredCharacter')
+        end
+
+        it "skips retired characters when specified as a default setting" do
+          user.update!(default_hide_retired_characters: true)
+          login_as(user)
+          get :index, params: { user_id: user.id }
+          expect(response.body).to include('ExistingCharacter')
+          expect(response.body).not_to include('RetiredCharacter')
+        end
+
+        it "still shows retired characters when default setting is overridden" do
+          user.update!(default_hide_retired_characters: true)
+          login_as(user)
+          get :index, params: { user_id: user.id, retired: 'true' }
+          expect(response.body).to include('ExistingCharacter')
+          expect(response.body).to include('RetiredCharacter')
+        end
       end
     end
   end

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe CharactersController do
       let!(:user) { create(:user) }
       let!(:character) { create(:character, user: user, name: 'ExistingCharacter') }
       let(:template) { create(:template, user: user) }
-      let(:template_character) { create(:character, template: template, user: user)}
+      let(:template_character) { create(:character, template: template, user: user) }
 
       it "successfully renders the page in template group" do
         template_character
@@ -103,6 +103,22 @@ RSpec.describe CharactersController do
           end
         end
 
+        context "without grouping" do
+          let(:characters) do
+            list = create_list(:character, 51, user: user) # rubocop:disable FactoryBot/ExcessiveCreateList
+            Character.where(id: list.map(&:id)).ordered
+          end
+
+          it "in icon view" do
+            get :index, params: { user_id: user.id, character_split: 'none', view: 'icons' }
+            expect(response.body).not_to include(characters.last.name)
+          end
+
+          it "in list view" do
+            get :index, params: { user_id: user.id, character_split: 'none', view: 'list' }
+            expect(response.body).not_to include(characters.to_ary[26].name)
+          end
+        end
       end
 
       context "retired" do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe GalleriesController do
         expect(response).to redirect_to(root_url)
       end
     end
+
+    it "paginates many galleries" do
+      user = create(:user)
+      create_list(:gallery, 101, user: user) # rubocop:disable FactoryBot/ExcessiveCreateList
+      get :index, params: { user_id: user.id }
+      expect(assigns(:galleries).size).to eq(100)
+      expect(assigns(:galleries).total_pages).to eq(2)
+    end
   end
 
   describe "GET new" do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -230,6 +230,14 @@ RSpec.describe GalleriesController do
           expect(assigns(:user)).to eq(user)
         end
       end
+
+      it "paginates large galleryless" do
+        user = create(:user)
+        create_list(:icon, 101, user: user) # rubocop:disable FactoryBot/ExcessiveCreateList
+        get :show, params: { id: '0', user_id: user.id }
+        expect(assigns(:icons).size).to eq(100)
+        expect(assigns(:icons).total_pages).to eq(2)
+      end
     end
 
     context "with normal gallery id" do
@@ -287,6 +295,13 @@ RSpec.describe GalleriesController do
         expect(meta_og[:url]).to eq(gallery_url(gallery))
         expect(meta_og[:title]).to eq("user » gallery")
         expect(meta_og[:description]).to eq("16 icons\nTags: Tag 1, Tag 2")
+      end
+
+      it "paginates large gallery" do
+        gallery = create(:gallery, icon_count: 101)
+        get :show, params: { id: gallery.id }
+        expect(assigns(:icons).size).to eq(100)
+        expect(assigns(:icons).total_pages).to eq(2)
       end
     end
 


### PR DESCRIPTION
- Paginates large sectioned boards by section (per page: 25)
- Paginates large character views by template in template view IF the user has more than 50 templates AND the the user does not have character groups (per page: 25)
- Paginates ungrouped character pages IF the user has more than 100 characters (per page: 25 for list view, 50 for icon view)
- Paginates galleries#index (per page: 100)
- Paginates galleries#show (per page: 100)