### PR TITLE
Move codeclimate test ID back to actions file

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           coverageCommand: bundle exec rspec spec --format documentation --format html --out rspec-results.html
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          CC_TEST_REPORTER_ID: a3ae0fa6dd28afe102a694b98ced6bb567577524d44571589c4ed1a68f8cda2d
       - name: Upload MinIO logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Apparently it's not considered secret

https://docs.codeclimate.com/docs/finding-your-test-coverage-token#should-i-keep-my-test-reporter-id-secret