### PR TITLE
Fix pagination and notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -26,7 +26,7 @@ class NotificationsController < ApplicationController
         redirect_to notifications_path and return
     end
 
-    flash[:success] = "Messages updated"
+    flash[:success] = "Notifications updated"
     redirect_to notifications_path
   end
 end

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -31,9 +31,9 @@
 %tr
   %td.icons-box.left-align
     .character-icon-list
-      - characters = characters.left_outer_joins(:default_icon).pluck(:id, :name, :screenname, :user_id, :url, :keyword)
-      = render partial: 'characters/icon_item', collection: characters, as: :character
-      - unless characters.present?
+      - charpluck = characters.left_outer_joins(:default_icon).pluck(:id, :name, :screenname, :user_id, :url, :keyword)
+      = render partial: 'characters/icon_item', collection: charpluck, as: :character
+      - unless charpluck.present?
         .centered — No characters yet —
 - if characters.methods.include?(:total_pages) && characters.total_pages > 1
   %tfoot

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -79,8 +79,12 @@
       - templates = @user.templates.ordered
       - templates = templates.paginate(per_page: 25, page: params[:page]) if templates.count > 50
       = render partial: partial_type, collection: templates, as: :name
-      - if (templateless = @user.characters.non_npcs.where(template_id: nil)).exists? && (templates.methods.exclude?(:total_pages) || templates.total_pages == params[:page])
+      - templateless = @user.characters.non_npcs.where(template_id: nil)
+      - if templateless.exists? && (templates.methods.exclude?(:total_pages) || templates.total_pages == params[:page])
         = render partial_type, name: "No Template", characters: templateless.ordered, show_new_character_button: @user.id == current_user&.id
+      - if templates.methods.include?(:total_pages) && templates.total_pages > 1
+        %tr
+          %td{colspan: colspan}= render 'posts/paginator', paginated: templates
     - else
       %tr
         %td.centered.padding-5{class: cycle('even', 'odd'), colspan: colspan} — No characters yet —

--- a/app/views/notifications/index.haml
+++ b/app/views/notifications/index.haml
@@ -6,13 +6,17 @@
         %th.sub
         %th.sub{colspan: 4} Notification
         %th.sub Received
+        %th.sub
     %tbody
       = render partial: "notification", collection: @notifications
+      - unless @notifications.present?
+        %tr
+          %td.centered.padding-10.no-posts{ class: cycle('even', 'odd'), colspan: 7 } — No posts yet —
       %tr
         %td.right-align.padding-5{colspan: 7, class: cycle('even', 'odd')}
           = submit_tag "Mark Read", class: 'button'
           = submit_tag "Mark Unread", class: 'button'
-          = submit_tag "Delete", class: 'button', data: { confirm: "Are you sure you want to delete these messages?" }
+          = submit_tag "Delete", class: 'button', data: { confirm: "Are you sure you want to delete these notifications?" }
   - if @notifications.total_pages > 1
     %tfoot
       %tr


### PR DESCRIPTION
- Adds a paginator on template view
- Renames the pluck on characters icon view to avoid the pagination getting overwritten (and making the footer not display)
- Updates some uses of 'messages' around notifications
- Adds a 'none yet' if there are no notifications
- Fixes the notifications header