### PR TITLE
Fix notifications pagination

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,11 +4,12 @@ class NotificationsController < ApplicationController
 
   def index
     @page_title = "Notifications"
-    @notifications = current_user.notifications.visible_to(current_user).ordered.paginate(page: page)
+    @notifications = current_user.notifications.visible_to(current_user).ordered
     @notifications = @notifications.not_ignored_by(current_user) if current_user&.hide_from_all
+    @notifications = @notifications.paginate(page: page)
 
     post_ids = @notifications.map(&:post_id).compact_blank
-    @posts = posts_from_relation(Post.where(id: post_ids)).index_by(&:id)
+    @posts = posts_from_relation(Post.where(id: post_ids), with_pagination: false).index_by(&:id)
   end
 
   def mark

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe NotificationsController do
       expect(flash[:error]).not_to be_present
     end
 
+    it "handles later pages" do
+      notifications = create_list(:notification, 15, user: user)
+      create_list(:notification, 25, user: user)
+      post_ids = notifications.map(&:post_id).compact_blank
+      login_as(user)
+      get :index, params: { page: 2 }
+      expect(assigns(:notifications).map(&:id)).to match_array(notifications.map(&:id))
+      expect(assigns(:posts).keys).to match_array(post_ids)
+      expect(flash[:error]).not_to be_present
+    end
+
     it "respects post visibility" do
       create(:notification, user: user, notification_type: :new_favorite_post, post: create(:post, privacy: :private))
       create(:notification, user: user, notification_type: :new_favorite_post, post: create(:post, privacy: :access_list))


### PR DESCRIPTION
- Moves the pagination to after hide_from_all filter
- Specifies with_pagination: false on posts-from-relation call
- Tests notification pages now behave properly