### PR TITLE
Modernize eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,6 +99,11 @@ export default [
         },
       ],
 
+      // ECMAScript 6
+      "no-const-assign": 2,
+      "no-var": 2,
+      "prefer-const": 1,
+
       // Stylistic Issues
       camelcase: [
         1,
@@ -122,18 +127,56 @@ export default [
       ],
       "no-unneeded-ternary": 2,
       "operator-assignment": 1,
+      "@stylistic/dot-location": [2, "property"],
+      "@stylistic/no-floating-decimal": 2,
+      "@stylistic/no-multi-spaces": 2,
+      "@stylistic/wrap-iife": 2,
+      "@stylistic/array-bracket-spacing": 1,
+      "@stylistic/block-spacing": 1,
+      "@stylistic/brace-style": [
+        1,
+        "1tbs",
+        {
+          allowSingleLine: true,
+        },
+      ],
+      "@stylistic/comma-spacing": 1,
+      "@stylistic/comma-style": 1,
+      "@stylistic/computed-property-spacing": 1,
+      "@stylistic/eol-last": 1,
+      "@stylistic/func-call-spacing": 1,
+      "@stylistic/indent": [2, 2, {"SwitchCase": 0}],
+      "@stylistic/jsx-quotes": [1, "prefer-single"],
+      "@stylistic/key-spacing": 1,
+      "@stylistic/keyword-spacing": 2,
+      "@stylistic/linebreak-style": 1,
+      "@stylistic/new-parens": 1,
+      "@stylistic/no-mixed-operators": 2,
+      "@stylistic/no-trailing-spaces": 2,
+      "@stylistic/no-whitespace-before-property": 2,
+      "@stylistic/semi": 2,
+      "@stylistic/semi-spacing": 2,
+      "@stylistic/space-before-blocks": 2,
+      "@stylistic/space-before-function-paren": [
+        2,
+        {
+          anonymous: "never",
+          named: "never",
+          asyncArrow: "always",
+        },
+      ],
+      "@stylistic/space-in-parens": 1,
+      "@stylistic/space-unary-ops": 1,
+      "@stylistic/spaced-comment": [
+        2,
+        "always",
+        {
+          markers: ["= require"],
+        },
+      ],
 
-      // ECMAScript 6
-      "no-const-assign": 2,
-      "no-var": 2,
-      "prefer-const": 1,
-
-      // deprecated options needing replacement (possibly style):
-      "dot-location": [2, "property"],
-      "no-floating-decimal": 2,
-      "no-multi-spaces": 2,
+      // deprecated options needing replacement (not style)
       "no-return-await": 2,
-      "wrap-iife": 2,
       "callback-return": 2,
       "global-require": 2,
       "handle-callback-err": 2,
@@ -144,49 +187,6 @@ export default [
       "no-process-exit": 2,
       "no-restricted-modules": 2,
       "no-sync": 1,
-      "array-bracket-spacing": 1,
-      "block-spacing": 1,
-      "brace-style": [
-        1,
-        "1tbs",
-        {
-          allowSingleLine: true,
-        },
-      ],
-      "comma-spacing": 1,
-      "comma-style": 1,
-      "computed-property-spacing": 1,
-      "eol-last": 1,
-      "func-call-spacing": 1,
-      indent: [2, 2],
-      "jsx-quotes": [1, "prefer-single"],
-      "key-spacing": 1,
-      "keyword-spacing": 2,
-      "linebreak-style": 1,
-      "new-parens": 1,
-      "no-mixed-operators": 2,
-      "no-trailing-spaces": 2,
-      "no-whitespace-before-property": 2,
-      semi: 2,
-      "semi-spacing": 2,
-      "space-before-blocks": 2,
-      "space-before-function-paren": [
-        2,
-        {
-          anonymous: "never",
-          named: "never",
-          asyncArrow: "always",
-        },
-      ],
-      "space-in-parens": 1,
-      "space-unary-ops": 1,
-      "spaced-comment": [
-        2,
-        "always",
-        {
-          markers: ["= require"],
-        },
-      ],
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -174,19 +174,6 @@ export default [
           markers: ["= require"],
         },
       ],
-
-      // deprecated options needing replacement (not style)
-      "no-return-await": 2,
-      "callback-return": 2,
-      "global-require": 2,
-      "handle-callback-err": 2,
-      "no-mixed-requires": 1,
-      "no-new-require": 1,
-      "no-path-concat": 2,
-      "no-process-env": 1,
-      "no-process-exit": 2,
-      "no-restricted-modules": 2,
-      "no-sync": 1,
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,28 +23,23 @@ export default [
         ...globals.jquery,
       },
 
-      ecmaVersion: 6,
+      ecmaVersion: 2015, // ECMA 6
       sourceType: "script",
     },
 
+    linterOptions: {
+      reportUnusedDisableDirectives: "warn"
+    },
+
     rules: {
-      // Possible Errors
-      "no-console": 0,
-      "no-extra-parens": 0,
-      "no-negated-in-lhs": 2,
-      "valid-jsdoc": 0,
       // Best Practices
       "accessor-pairs": 2,
       "block-scoped-var": 2,
       complexity: [2, 6],
       "consistent-return": 1,
-      curly: 0,
-      "default-case": 0,
-      "dot-location": [2, "property"],
       "dot-notation": 1,
       eqeqeq: 2,
       "guard-for-in": 2,
-      "no-alert": 0,
       "no-caller": 1,
       "no-div-regex": 2,
       "no-else-return": 2,
@@ -54,27 +49,21 @@ export default [
       "no-extend-native": 2,
       "no-extra-bind": 2,
       "no-extra-label": 2,
-      "no-floating-decimal": 2,
       "no-implicit-coercion": 2,
-      "no-implicit-globals": 0,
       "no-implied-eval": 2,
       "no-invalid-this": 2,
       "no-iterator": 2,
       "no-labels": 2,
       "no-lone-blocks": 2,
       "no-loop-func": 2,
-      "no-magic-numbers": 0,
-      "no-multi-spaces": 2,
       "no-multi-str": 2,
       "no-new": 2,
       "no-new-func": 2,
       "no-new-wrappers": 2,
       "no-octal-escape": 2,
-      "no-param-reassign": 0,
       "no-proto": 2,
       "no-restricted-properties": 2,
       "no-return-assign": 2,
-      "no-return-await": 2,
       "no-script-url": 2,
       "no-self-compare": 2,
       "no-sequences": 2,
@@ -87,22 +76,15 @@ export default [
       "no-void": 2,
       "no-warning-comments": 1,
       "prefer-promise-reject-errors": 2,
-      radix: 0,
       "require-await": 1,
-      "vars-on-top": 0,
-      "wrap-iife": 2,
       yoda: 1,
-      // Strict
-      strict: 0,
+      
       // Variables
-      "init-declarations": 0,
-      "no-catch-shadow": 2,
       "no-label-var": 2,
       "no-restricted-globals": 2,
       "no-shadow": 2,
       "no-undef-init": 2,
       "no-undefined": 2,
-
       "no-unused-vars": [
         2,
         {
@@ -110,7 +92,6 @@ export default [
           argsIgnorePattern: "^_.*$",
         },
       ],
-
       "no-use-before-define": [
         2,
         {
@@ -118,7 +99,41 @@ export default [
         },
       ],
 
-      // Node.js and CommonJS
+      // Stylistic Issues
+      camelcase: [
+        1,
+        {
+          properties: "never",
+        },
+      ],
+      "max-statements": [1, 30],
+      "no-array-constructor": 1,
+      "no-bitwise": 1,
+      "no-lonely-if": 1,
+      "no-multi-assign": 1,
+      "no-negated-condition": 1,
+      "no-nested-ternary": 1,
+      "no-object-constructor": 2,
+      "no-plusplus": [
+        2,
+        {
+          allowForLoopAfterthoughts: true,
+        },
+      ],
+      "no-unneeded-ternary": 2,
+      "operator-assignment": 1,
+
+      // ECMAScript 6
+      "no-const-assign": 2,
+      "no-var": 2,
+      "prefer-const": 1,
+
+      // deprecated options needing replacement (possibly style):
+      "dot-location": [2, "property"],
+      "no-floating-decimal": 2,
+      "no-multi-spaces": 2,
+      "no-return-await": 2,
+      "wrap-iife": 2,
       "callback-return": 2,
       "global-require": 2,
       "handle-callback-err": 2,
@@ -129,11 +144,8 @@ export default [
       "no-process-exit": 2,
       "no-restricted-modules": 2,
       "no-sync": 1,
-
-      // Stylistic Issues
       "array-bracket-spacing": 1,
       "block-spacing": 1,
-
       "brace-style": [
         1,
         "1tbs",
@@ -141,93 +153,23 @@ export default [
           allowSingleLine: true,
         },
       ],
-
-      camelcase: [
-        1,
-        {
-          properties: "never",
-        },
-      ],
-
-      "capitalized-comments": 0,
-      "comma-dangle": 0,
       "comma-spacing": 1,
       "comma-style": 1,
       "computed-property-spacing": 1,
-      "consistent-this": 0,
       "eol-last": 1,
       "func-call-spacing": 1,
-      "func-name-matching": 0,
-      "func-names": 0,
-      "func-style": 0,
-      "id-blacklist": 0,
-      "id-length": 0,
-      "id-match": 0,
       indent: [2, 2],
       "jsx-quotes": [1, "prefer-single"],
       "key-spacing": 1,
       "keyword-spacing": 2,
-      "line-comment-position": 0,
       "linebreak-style": 1,
-      "lines-around-comment": 0,
-      "lines-around-directive": 0,
-      "max-depth": 0,
-      "max-len": 0,
-      "max-lines": 0,
-      "max-nested-callbacks": 0,
-      "max-params": 0,
-      "max-statements": [1, 30],
-      "max-statements-per-line": 0,
-      "multiline-ternary": 0,
-      "new-cap": 0,
       "new-parens": 1,
-      "newline-after-var": 0,
-      "newline-before-return": 0,
-      "newline-per-chained-call": 0,
-      "no-array-constructor": 1,
-      "no-bitwise": 1,
-      "no-continue": 0,
-      "no-inline-comments": 0,
-      "no-lonely-if": 1,
       "no-mixed-operators": 2,
-      "no-multi-assign": 1,
-      "no-multiple-empty-lines": 0,
-      "no-negated-condition": 1,
-      "no-nested-ternary": 1,
-      "no-new-object": 2,
-
-      "no-plusplus": [
-        2,
-        {
-          allowForLoopAfterthoughts: true,
-        },
-      ],
-
-      "no-restricted-syntax": 0,
-      "no-tabs": 0,
-      "no-ternary": 0,
       "no-trailing-spaces": 2,
-      "no-underscore-dangle": 0,
-      "no-unneeded-ternary": 2,
       "no-whitespace-before-property": 2,
-      "nonblock-statement-body-position": 0,
-      "object-curly-newline": 0,
-      "object-curly-spacing": 0,
-      "object-property-newline": 0,
-      "one-var": 0,
-      "one-var-declaration-per-line": 0,
-      "operator-assignment": 1,
-      "operator-linebreak": 0,
-      "padded-blocks": 0,
-      "quote-props": 0,
-      quotes: 0,
-      "require-jsdoc": 0,
       semi: 2,
       "semi-spacing": 2,
-      "sort-keys": 0,
-      "sort-vars": 0,
       "space-before-blocks": 2,
-
       "space-before-function-paren": [
         2,
         {
@@ -236,11 +178,8 @@ export default [
           asyncArrow: "always",
         },
       ],
-
       "space-in-parens": 1,
-      "space-infix-ops": 0,
       "space-unary-ops": 1,
-
       "spaced-comment": [
         2,
         "always",
@@ -248,25 +187,6 @@ export default [
           markers: ["= require"],
         },
       ],
-
-      "template-tag-spacing": 0,
-      "unicode-bom": 0,
-      "wrap-regex": 0,
-
-      // ECMAScript 6
-      "arrow-body-style": 0,
-      "arrow-parens": 0,
-      "arrow-spacing": 0,
-      "generator-star-spacing": 0,
-      "no-arrow-condition": 0,
-      "no-const-assign": 2,
-      "no-var": 2,
-      "object-shorthand": 0,
-      "prefer-arrow-callback": 0,
-      "prefer-const": 1,
-      "prefer-reflect": 0,
-      "prefer-spread": 0,
-      "prefer-template": 0,
     },
   },
 ];


### PR DESCRIPTION
In our config as `0` but not part of recommended anyway (i.e. overriding to the same value), removing:

```js
"no-console": 0,
curly: 0, // but maybe we want to enable this?
"default-case": 0,
"no-alert": 0,
"no-implicit-globals": 0,
"no-magic-numbers": 0,
"no-param-reassign": 0,
radix: 0,
"vars-on-top": 0,
strict: 0,
"init-declarations": 0,
"capitalized-comments": 0,
"consistent-this": 0,
"func-name-matching": 0,
"func-names": 0,
"func-style": 0,
"id-blacklist": 0,
"id-length": 0,
"id-match": 0,
"max-depth": 0,
"max-lines": 0,
"max-nested-callbacks": 0,
"max-params": 0,
"new-cap": 0,
"no-continue": 0,
"no-inline-comments": 0,
"no-restricted-syntax": 0,
"no-ternary": 0,
"no-underscore-dangle": 0,
"one-var": 0,
"sort-keys": 0,
"sort-vars": 0,
"unicode-bom": 0,
"arrow-body-style": 0,
"object-shorthand": 0,
"prefer-arrow-callback": 0,
"prefer-spread": 0,
"prefer-template": 0,
```

Replaced by alternative rules:

```js
"no-negated-in-lhs": 2, // -> no-unsafe-negation, part of recommended
"no-catch-shadow": 2, // -> no-shadow, already at 2
"no-new-object": 2, // -> no-object-constructor, renamed
"no-arrow-condition": 0, // -> no-confusing-arrow, deprecated; no-constant-condition, part of recommended
```

Deprecated rules:
```js
// previously disabled, no need to transition
"no-extra-parens": 0,
"valid-jsdoc": 0,
"comma-dangle": 0,
"line-comment-position": 0,
"lines-around-comment": 0,
"lines-around-directive": 0,
"max-len": 0,
"max-statements-per-line": 0,
"multiline-ternary": 0,
"newline-after-var": 0,
"newline-before-return": 0,
"newline-per-chained-call": 0,
"no-multiple-empty-lines": 0,
"no-tabs": 0,
"nonblock-statement-body-position": 0,
"object-curly-newline": 0,
"object-curly-spacing": 0,
"object-property-newline": 0,
"one-var-declaration-per-line": 0,
"operator-linebreak": 0,
"padded-blocks": 0,
"quote-props": 0,
quotes: 0,
"require-jsdoc": 0,
"space-infix-ops": 0,
"template-tag-spacing": 0,
"wrap-regex": 0,
"arrow-parens": 0,
"arrow-spacing": 0,
"generator-star-spacing": 0,
"prefer-reflect": 0,

// previously enabled, now deprecated, but only relevant to Node.js
// could use a replacement, but we don't use Node.js
// https://github.com/eslint-community/eslint-plugin-n
"callback-return": 2,
"global-require": 2,
"handle-callback-err": 2,
"no-mixed-requires": 1,
"no-new-require": 1,
"no-path-concat": 2,
"no-process-env": 1,
"no-process-exit": 2,
"no-restricted-modules": 2,
"no-sync": 1,

// previously enabled, now transitioned to @stylistic
"@stylistic/dot-location": [2, "property"],
"@stylistic/no-floating-decimal": 2,
"@stylistic/no-multi-spaces": 2,
"@stylistic/wrap-iife": 2,
"@stylistic/array-bracket-spacing": 1,
"@stylistic/block-spacing": 1,
"@stylistic/brace-style": [
  1,
  "1tbs",
  {
    allowSingleLine: true,
  },
],
"@stylistic/comma-spacing": 1,
"@stylistic/comma-style": 1,
"@stylistic/computed-property-spacing": 1,
"@stylistic/eol-last": 1,
"@stylistic/func-call-spacing": 1,
"@stylistic/indent": [2, 2, {"SwitchCase": 0}],
"@stylistic/jsx-quotes": [1, "prefer-single"],
"@stylistic/key-spacing": 1,
"@stylistic/keyword-spacing": 2,
"@stylistic/linebreak-style": 1,
"@stylistic/new-parens": 1,
"@stylistic/no-mixed-operators": 2,
"@stylistic/no-trailing-spaces": 2,
"@stylistic/no-whitespace-before-property": 2,
"@stylistic/semi": 2,
"@stylistic/semi-spacing": 2,
"@stylistic/space-before-blocks": 2,
"@stylistic/space-before-function-paren": [
  2,
  {
    anonymous: "never",
    named: "never",
    asyncArrow: "always",
  },
],
"@stylistic/space-in-parens": 1,
"@stylistic/space-unary-ops": 1,
"@stylistic/spaced-comment": [
  2,
  "always",
  {
    markers: ["= require"],
  },
],

// previously enabled, no replacement
"no-return-await": 2,  // this is only stylistic as of recent V8 JavaScript engine versions
```