### PR TITLE
Fix viewbutton selected color on starry

### DIFF
--- a/app/assets/stylesheets/layouts/_starry_default_variables.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_variables.scss
@@ -83,4 +83,4 @@ $bg_color_linkbox_dismiss: $colors_mulledwine !default;
 
 // other buttons
 $bg_color_viewbutton: $colors_mulledwine !default;
-$bg_color_viewbutton_selected: $colors_mulledwine !default;
+$bg_color_viewbutton_selected: #4D4B5B !default;


### PR DESCRIPTION
Very low contrast, but uses an existing palette color (from `$font_color_input`) and is better than nothing!

![image](https://github.com/user-attachments/assets/94ce9576-3b28-44a4-b41a-c85cb574a2d4)

(`markdown` is selected here)