### PR TITLE
Upgrade puma to 6.5.0, relax rackup constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem 'nokogiri'
 gem 'pg', '~> 1.5'
 gem 'pg_search'
 gem 'rack-pratchett'
-gem 'rackup', '!= 1.0.1', require: false # rackup 1.0.1 is incompatible with puma <= 6.4.3
 gem 'rails', '~> 7.1.5'
 gem "redcarpet", "~> 3.6"
 gem 'redis', '~> 5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
     psych (5.2.0)
       stringio
     public_suffix (6.0.1)
-    puma (6.4.3)
+    puma (6.5.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,7 +628,6 @@ DEPENDENCIES
   rack-mini-profiler
   rack-pratchett
   rack-timeout (>= 0.6.0)
-  rackup (!= 1.0.1)
   rails (~> 7.1.5)
   rails-controller-testing
   rake (~> 13.2)


### PR DESCRIPTION
Puma 6.5.0 was released with the fix for rackup: https://github.com/puma/puma/releases/tag/v6.5.0:

> `lib/rack/handler/puma.rb - fix for rackup v1.0.1, adjust Gemfile ([https://github.com/puma/puma/pull/3532], [https://github.com/puma/puma/issues/3531])`