### PR TITLE
Fix template "All Characters" button with default hidden retired

### DIFF
--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -36,7 +36,7 @@
             .view-button
               Hide Retired
         - else
-          = link_to character_menu_link(retired: nil), class: 'view-button-link' do
+          = link_to character_menu_link(retired: true), class: 'view-button-link' do
             .view-button
               All Characters
   %tbody


### PR DESCRIPTION
When your account defaults to hiding retired characters, we need to specify explicitly `retired=true` in the URL to get retired characters to show up. This already worked on the characters page, but not on `template#show`.