### PR TITLE
Add option to retire templates

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -121,6 +121,6 @@ class TemplatesController < ApplicationController
   end
 
   def permitted_params
-    params.fetch(:template, {}).permit(:name, :description, character_ids: [])
+    params.fetch(:template, {}).permit(:name, :description, :retired, character_ids: [])
   end
 end

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -14,7 +14,7 @@ class WritableController < ApplicationController
       user.characters.non_npcs.where(template_id: nil, retired: false).ordered.pluck(Template::CHAR_PLUCK),
     )
     @templates = templates + [templateless]
-    all_npcs = faked_npcs.new('All NPCs', nil, user.characters.where(retired: false).npcs.ordered.pluck(Template::NPC_PLUCK))
+    all_npcs = faked_npcs.new('All NPCs', nil, user.characters.npcs.not_retired.ordered.pluck(Template::NPC_PLUCK))
     @npcs = [all_npcs]
 
     if @post

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -39,6 +39,10 @@ class Character < ApplicationRecord
   scope :with_name, ->(charname) { where("concat_ws(' | ', name, nickname, screenname) ILIKE ?", "%#{charname}%") }
   scope :npcs, -> { where(npc: true) }
   scope :non_npcs, -> { where(npc: false) }
+  scope :not_retired, -> do
+    base = where(retired: false).left_outer_joins(:template)
+    base.where(template_id: nil).or(base.where(template: { retired: false }))
+  end
 
   accepts_nested_attributes_for :template, reject_if: :all_blank
 

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -9,8 +9,8 @@ class Template < ApplicationRecord
 
   scope :ordered, -> { order(name: :asc, created_at: :asc, id: :asc) }
 
-  CHAR_PLUCK = Arel.sql("id, concat_ws(' | ', name, nickname, screenname)")
-  NPC_PLUCK = Arel.sql("id, concat_ws(' | ', name, nickname)")
+  CHAR_PLUCK = Arel.sql("characters.id as id, concat_ws(' | ', characters.name, nickname, screenname)")
+  NPC_PLUCK = Arel.sql("characters.id as id, concat_ws(' | ', characters.name, nickname)")
 
   def plucked_characters
     characters.non_npcs.not_retired.pluck(CHAR_PLUCK)

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -13,6 +13,6 @@ class Template < ApplicationRecord
   NPC_PLUCK = Arel.sql("id, concat_ws(' | ', name, nickname)")
 
   def plucked_characters
-    characters.non_npcs.where(retired: false).pluck(CHAR_PLUCK)
+    characters.non_npcs.not_retired.pluck(CHAR_PLUCK)
   end
 end

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -1,5 +1,5 @@
 - characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
-- characters = characters.where(retired: false) unless local_assigns[:ignore_retired_filter] || local_assigns.fetch(:show_retired) { show_retired }
+- characters = characters.not_retired unless local_assigns[:ignore_retired_filter] || local_assigns.fetch(:show_retired) { show_retired }
 
 - if @template.nil? && name.present?
   %tr

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -1,5 +1,5 @@
 - characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
-- characters = characters.where(retired: false) unless local_assigns.fetch(:show_retired) { show_retired }
+- characters = characters.where(retired: false) unless local_assigns[:ignore_retired_filter] || local_assigns.fetch(:show_retired) { show_retired }
 
 - if @template.nil? && name.present?
   %tr

--- a/app/views/characters/_icon_view.haml
+++ b/app/views/characters/_icon_view.haml
@@ -1,5 +1,5 @@
 - characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
-- characters = characters.not_retired unless local_assigns[:ignore_retired_filter] || local_assigns.fetch(:show_retired) { show_retired }
+- characters = characters.not_retired unless local_assigns.fetch(:show_retired) { show_retired }
 
 - if @template.nil? && name.present?
   %tr

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -1,7 +1,7 @@
 - col_count = 7
 - col_count += 1 if local_assigns[:show_template]
 - characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
-- characters = characters.not_retired unless local_assigns[:ignore_retired_filter] || show_retired
+- characters = characters.not_retired unless local_assigns.fetch(:show_retired) { show_retired }
 
 - if @template.nil? && name.present?
   %tr

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -1,7 +1,7 @@
 - col_count = 7
 - col_count += 1 if local_assigns[:show_template]
 - characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
-- characters = characters.where(retired: false) unless local_assigns[:ignore_retired_filter] || show_retired
+- characters = characters.not_retired unless local_assigns[:ignore_retired_filter] || show_retired
 
 - if @template.nil? && name.present?
   %tr

--- a/app/views/characters/_list_section.haml
+++ b/app/views/characters/_list_section.haml
@@ -1,7 +1,7 @@
 - col_count = 7
 - col_count += 1 if local_assigns[:show_template]
 - characters = name.characters.non_npcs.ordered unless local_assigns[:characters]
-- characters = characters.where(retired: false) unless show_retired
+- characters = characters.where(retired: false) unless local_assigns[:ignore_retired_filter] || show_retired
 
 - if @template.nil? && name.present?
   %tr

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -77,6 +77,7 @@
         = render 'group', characters: group_chars, group: nil, skip_grouped_templates: true, page_view: page_view, colspan: colspan
     - elsif @user.characters.exists?
       - templates = @user.templates.ordered
+      - templates = templates.where(retired: false) unless show_retired
       - templates = templates.paginate(per_page: 25, page: params[:page]) if templates.count > 50
       = render partial: partial_type, collection: templates, as: :name
       - templateless = @user.characters.non_npcs.where(template_id: nil)

--- a/app/views/templates/_editor.haml
+++ b/app/views/templates/_editor.haml
@@ -5,6 +5,11 @@
   %tr
     %th.sub.vtop= f.label :description
     %td.odd= f.text_area :description
+  %tr
+    %th.sub= f.label :retired, 'Retired?'
+    %td{class: cycle('even', 'odd')}
+      = f.check_box :retired, class: 'vmid'
+      = f.label :retired, 'Do not display member characters in character selector', class: 'no-margin'
   - if @selectable_characters.present?
     %tr
       %th.sub.vtop= f.label :characters_ids, 'Characters'

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -42,9 +42,9 @@
                 All Characters
   %tbody
     - if page_view == 'list'
-      = render 'characters/list_section', characters: @template.characters, ignore_retired_filter: @template.retired
+      = render 'characters/list_section', characters: @template.characters, show_retired: @template.retired || show_retired
     - else
-      = render 'characters/icon_view', characters: @template.characters, ignore_retired_filter: @template.retired
+      = render 'characters/icon_view', characters: @template.characters, show_retired: @template.retired || show_retired
 - if @posts.present?
   %br
   - content_for(:posts_title) { 'Posts with Template Instances' }

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -31,19 +31,20 @@
           .view-button{class: (:selected if page_view == 'list')}
             = image_tag "icons/list.png", class: 'list-view', alt: ''
             List
-        - if show_retired
-          = link_to character_menu_link(retired: false), class: 'view-button-link' do
-            .view-button
-              Hide Retired
-        - else
-          = link_to character_menu_link(retired: nil), class: 'view-button-link' do
-            .view-button
-              All Characters
+        - unless @template.retired # If the template is retired, it always shows all of its characters
+          - if show_retired
+            = link_to character_menu_link(retired: false), class: 'view-button-link' do
+              .view-button
+                Hide Retired
+          - else
+            = link_to character_menu_link(retired: nil), class: 'view-button-link' do
+              .view-button
+                All Characters
   %tbody
     - if page_view == 'list'
-      = render 'characters/list_section', characters: @template.characters
+      = render 'characters/list_section', characters: @template.characters, ignore_retired_filter: @template.retired
     - else
-      = render 'characters/icon_view', characters: @template.characters
+      = render 'characters/icon_view', characters: @template.characters, ignore_retired_filter: @template.retired
 - if @posts.present?
   %br
   - content_for(:posts_title) { 'Posts with Template Instances' }

--- a/db/migrate/20241130175900_add_retired_to_templates.rb
+++ b/db/migrate/20241130175900_add_retired_to_templates.rb
@@ -1,0 +1,5 @@
+class AddRetiredToTemplates < ActiveRecord::Migration[7.2]
+  def change
+    add_column :templates, :retired, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_09_30_053037) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_30_175900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -435,6 +435,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_30_053037) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.text "description"
+    t.boolean "retired", default: false
     t.index ["user_id"], name: "index_templates_on_user_id"
   end
 
@@ -473,5 +474,4 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_30_053037) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
-
 end

--- a/spec/controllers/characters_controller_spec.rb
+++ b/spec/controllers/characters_controller_spec.rb
@@ -122,12 +122,19 @@ RSpec.describe CharactersController do
       end
 
       context "retired" do
-        before(:each) { create(:character, user: user, retired: true, name: 'RetiredCharacter') }
+        before(:each) do
+          create(:character, user: user, retired: true, name: 'RetiredCharacter')
+
+          retired_template = create(:template, user: character.user, retired: true, name: 'RetiredTemplate')
+          create(:character, user: character.user, name: 'CharacterInRetiredTemplate', template: retired_template)
+        end
 
         it "skips retired characters when specified" do
           get :index, params: { user_id: user.id, retired: 'false' }
           expect(response.body).to include('ExistingCharacter')
           expect(response.body).not_to include('RetiredCharacter')
+          expect(response.body).not_to include('RetiredTemplate')
+          expect(response.body).not_to include('CharacterInRetiredTemplate')
         end
 
         it "skips retired characters when specified as a default setting" do
@@ -136,6 +143,8 @@ RSpec.describe CharactersController do
           get :index, params: { user_id: user.id }
           expect(response.body).to include('ExistingCharacter')
           expect(response.body).not_to include('RetiredCharacter')
+          expect(response.body).not_to include('RetiredTemplate')
+          expect(response.body).not_to include('CharacterInRetiredTemplate')
         end
 
         it "still shows retired characters when default setting is overridden" do
@@ -144,6 +153,8 @@ RSpec.describe CharactersController do
           get :index, params: { user_id: user.id, retired: 'true' }
           expect(response.body).to include('ExistingCharacter')
           expect(response.body).to include('RetiredCharacter')
+          expect(response.body).to include('RetiredTemplate')
+          expect(response.body).to include('CharacterInRetiredTemplate')
         end
       end
     end

--- a/spec/controllers/templates_controller_spec.rb
+++ b/spec/controllers/templates_controller_spec.rb
@@ -50,13 +50,14 @@ RSpec.describe TemplatesController do
     it "works" do
       char = create(:character)
       login_as(char.user)
-      post :create, params: { template: { name: 'testtest', description: 'test desc', character_ids: [char.id] } }
+      post :create, params: { template: { name: 'testtest', description: 'test desc', character_ids: [char.id], retired: true } }
       created = Template.last
       expect(response).to redirect_to(template_url(created))
       expect(flash[:success]).to eq("Template created.")
       expect(created.name).to eq('testtest')
       expect(created.description).to eq('test desc')
       expect(created.characters).to match_array([char])
+      expect(created.retired).to eq(true)
     end
   end
 
@@ -207,6 +208,7 @@ RSpec.describe TemplatesController do
           name: new_name,
           description: 'new desc',
           character_ids: [char.id],
+          retired: true,
         },
       }
       expect(response).to redirect_to(template_url(template))
@@ -216,6 +218,7 @@ RSpec.describe TemplatesController do
       expect(template.name).to eq(new_name)
       expect(template.description).to eq('new desc')
       expect(template.characters).to match_array([char])
+      expect(template.retired).to eq(true)
     end
   end
 

--- a/spec/controllers/writable_controller_spec.rb
+++ b/spec/controllers/writable_controller_spec.rb
@@ -224,12 +224,15 @@ RSpec.describe WritableController do
       expect(templates.first.plucked_characters).to eq(info)
     end
 
-    it "excludes retired templated characters" do
+    it "excludes retired characters" do
       user = create(:user)
       template = create(:template, user: user)
       char1 = create(:character, template: template, user: user, name: 'AAAA')
       create_list(:character, 2, template: template, user: user, retired: true)
       char2 = create(:character, template: template, user: user, name: 'DDDD', screenname: "screen_name", nickname: "Nickname")
+      create(:character, user: user, retired: true)
+      retired_template = create(:template, user: user, retired: true)
+      create(:character, template: retired_template, user: user)
       login_as(user)
       controller.send(:build_template_groups)
       templates = assigns(:templates)

--- a/spec/controllers/writable_controller_spec.rb
+++ b/spec/controllers/writable_controller_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe WritableController do
       expect(templates.first.plucked_characters).to eq(info)
     end
 
-    it "excludes retired templateless characters" do
+    it "excludes retired templated characters" do
       user = create(:user)
       template = create(:template, user: user)
       char1 = create(:character, template: template, user: user, name: 'AAAA')

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -263,6 +263,22 @@ RSpec.describe Character do
     end
   end
 
+  describe ".not_retired" do
+    it "works" do
+      template1 = create(:template, retired: false)
+      template2 = create(:template, retired: true)
+
+      char1 = create(:character, retired: false)
+      create(:character, retired: true)
+      char3 = create(:character, retired: false, template: template1)
+      create(:character, retired: true, template: template1)
+      create(:character, retired: false, template: template2)
+      create(:character, retired: true, template: template2)
+
+      expect(Character.not_retired).to match_array([char1, char3])
+    end
+  end
+
   describe "audits" do
     before(:each) do
       Character.auditing_enabled = true


### PR DESCRIPTION
Add an option to mark an entire template as retired, which causes it to not show up on the characters list if retired characters aren't shown and causes all of its members to not be selectable when writing posts or replies.