### PR TITLE
Fix vertical align of checkbox labels

### DIFF
--- a/app/views/admin/characters/_relocate.haml
+++ b/app/views/admin/characters/_relocate.haml
@@ -15,10 +15,10 @@
         %th.sub= f.label :user_id, 'New User Id'
         %td{class: cycle('even', 'odd')}= f.text_field :user_id, value: params[:user_id], placeholder: "New User", class: 'text'
       %tr
-        %td.sub With Templates
+        %th.sub With Templates
         %td.padding-5{class: cycle('even', 'odd')}
-          = f.check_box :include_templates, checked: params[:include_templates], class: 'vmid no-margin', style: 'margin-bottom: 3px;'
-          = f.label :include_templates, "Transfer Templates"
+          = f.check_box :include_templates, checked: params[:include_templates], class: 'vmid'
+          = f.label :include_templates, "Transfer Templates", class: 'vmid'
     %tfoot
       %tr
         %th.form-table-ender{colspan: 2}

--- a/app/views/admin/posts/regenerate_flat.haml
+++ b/app/views/admin/posts/regenerate_flat.haml
@@ -12,10 +12,10 @@
         %th.sub= f.label :before, 'Last Regenerated Before'
         %td{class: cycle('even', 'odd')}= f.datetime_field :before, value: params[:before] || Time.zone.now
       %tr
-        %td.sub Force Regenerate?
+        %th.sub Force Regenerate?
         %td.padding-5{class: cycle('even', 'odd')}
-          = f.check_box :force, checked: params[:force], class: 'vmid no-margin', style: 'margin-bottom: 3px;'
-          = f.label :force, "Include Flatposts Regenerated Since Post Last Tagged"
+          = f.check_box :force, checked: params[:force], class: 'vmid'
+          = f.label :force, "Include Flatposts Regenerated Since Post Last Tagged", class: 'vmid'
     %tfoot
       %tr
         %th.form-table-ender{colspan: 2}

--- a/app/views/blocks/_editor.haml
+++ b/app/views/blocks/_editor.haml
@@ -14,8 +14,8 @@
   %tr
     %th.sub= f.label :block_interactions, 'Interactions'
     %td{class: klass}
-      = f.check_box :block_interactions
-      = f.label :block_interactions, "Prevent them from interacting with you?"
+      = f.check_box :block_interactions, class: 'vmid'
+      = f.label :block_interactions, "Prevent them from interacting with you?", class: 'vmid'
   %tr
     %th.sub= f.label :hide_them
     %td{class: klass}

--- a/app/views/boards/_editor.haml
+++ b/app/views/boards/_editor.haml
@@ -19,7 +19,7 @@
     %th.sub= f.label :authors_locked, 'Locked?'
     %td.even
       = f.check_box :authors_locked, class: 'vmid', checked: @board.authors_locked
-      = f.label :authors_locked, 'Only allow authors to create new posts in this continuity', class: 'no-margin'
+      = f.label :authors_locked, 'Only allow authors to create new posts in this continuity', class: 'vmid'
   %tr
     %th.sub.vtop Description
     %td.odd= f.text_area :description

--- a/app/views/characters/_editor.haml
+++ b/app/views/characters/_editor.haml
@@ -22,7 +22,7 @@
       - if @character.user == current_user
         %br
         = check_box_tag :new_template, '1', params[:new_template].present?
-        = label_tag :new_template, 'Create New Template'
+        = label_tag :new_template, 'Create New Template', class: 'vmid'
   - if @character.user == current_user
     %tr#create_template{class: ('hidden' unless params[:new_template])}
       = f.fields_for :template do |ff|
@@ -53,12 +53,12 @@
     %th.sub= f.label :npc, 'NPC?'
     %td{class: cycle('even', 'odd')}
       = f.check_box :npc, class: 'vmid'
-      = f.label :npc, 'Remove from character page and show in separate dropdown when writing', class: 'no-margin'
+      = f.label :npc, 'Remove from character page and show in separate dropdown when writing', class: 'vmid'
   %tr
     %th.sub= f.label :retired, 'Retired?'
     %td{class: cycle('even', 'odd')}
       = f.check_box :retired, class: 'vmid'
-      = f.label :retired, 'Do not display in character selector', class: 'no-margin'
+      = f.label :retired, 'Do not display in character selector', class: 'vmid'
   - if current_user.id != @character.user_id
     %tr
       %th.sub.vtop= f.label :audit_comment, 'Moderator Note'

--- a/app/views/galleries/_add_existing.haml
+++ b/app/views/galleries/_add_existing.haml
@@ -15,8 +15,8 @@
       %th.sub Galleryless Icons
     %tr
       %td.even.padding-5#icons-0
-        = check_box_tag :select_all, 0, false, class: 'select-all'
-        Select all icons
+        = check_box_tag :select_all, 0, false, class: 'select-all vmid'
+        %span.vmid Select all icons
         %br
         - @unassigned.each do |icon|
           .gallery-icon
@@ -34,8 +34,8 @@
           .float-right.gallery-box{id: "minmax-#{gallery.id}"} +
       %tr
         %td.padding-5.hidden{class: cycle('even', 'odd'), id: "icons-#{gallery.id}"}
-          = check_box_tag :select_all, gallery.id, false, class: 'select-all', id: nil
-          Select all icons
+          = check_box_tag :select_all, gallery.id, false, class: 'select-all vmid', id: nil
+          %span.vmid Select all icons
           %br
     %tr
       %td.form-table-ender.padding-5

--- a/app/views/icons/_editor.haml
+++ b/app/views/icons/_editor.haml
@@ -32,12 +32,12 @@
     - if gif.present?
       %tr.gallery-icon-remove
         %td{class: cycle('even', 'odd'), colspan: 2}
-          = gif.check_box :_destroy
-          = gif.label :_destroy, 'Remove from Gallery'
+          = gif.check_box :_destroy, class: 'vmid'
+          = gif.label :_destroy, 'Remove from Gallery', class: 'vmid'
       %tr.gallery-icon-destroy
         %td{class: cycle('even', 'odd'), colspan: 2}
-          = f.check_box :_destroy
-          = f.label :_destroy, 'Delete Icon'
+          = f.check_box :_destroy, class: 'vmid'
+          = f.label :_destroy, 'Delete Icon', class: 'vmid'
   %tfoot
     - if gif.nil?
       %tr.submit-row

--- a/app/views/posts/_write.haml
+++ b/app/views/posts/_write.haml
@@ -67,7 +67,7 @@
     %div{title: 'If a post is locked, it doesn\'t accept new authors. Current or invited authors can still reply.'}
       = f.label :authors_locked, 'Lock post to authors?'
       = f.check_box :authors_locked, class: 'vmid', checked: @authors_from_board || @post.authors_locked
-      = f.label :authors_locked, 'Only allow current or invited authors to reply to this post', class: 'no-margin'
+      = f.label :authors_locked, 'Only allow current or invited authors to reply to this post', class: 'vmid'
 
     = f.label :setting_ids, 'Setting:'
     = tag_select(post, f, :settings)

--- a/app/views/tags/_editor.haml
+++ b/app/views/tags/_editor.haml
@@ -18,7 +18,7 @@
   %tr
     %th.sub= f.label :owned, 'Owned?'
     %td{class: cycle('even', 'odd')}
-      = f.check_box :owned, class: 'vmid'
+      = f.check_box :owned, class: 'vmid width-15'
       = f.label :owned, 'Tag belongs to owner', class: 'vmid'
   - if f.object.is_a?(Setting)
     %tr

--- a/app/views/tags/_editor.haml
+++ b/app/views/tags/_editor.haml
@@ -18,8 +18,8 @@
   %tr
     %th.sub= f.label :owned, 'Owned?'
     %td{class: cycle('even', 'odd')}
-      = f.check_box :owned, class: 'vmid width-15'
-      = f.label :owned, 'Tag belongs to owner'
+      = f.check_box :owned, class: 'vmid'
+      = f.label :owned, 'Tag belongs to owner', class: 'vmid'
   - if f.object.is_a?(Setting)
     %tr
       %th.sub= f.label :parent_settings

--- a/app/views/templates/_editor.haml
+++ b/app/views/templates/_editor.haml
@@ -11,14 +11,14 @@
     %th.sub= f.label :retired, 'Retired?'
     %td{class: cycle('even', 'odd')}
       = f.check_box :retired, class: 'vmid'
-      = f.label :retired, 'Do not display member characters in character selector', class: 'no-margin'
+      = f.label :retired, 'Do not display member characters in character selector', class: 'vmid'
   - if @selectable_characters.present?
     %tr
       %th.sub.vtop= f.label :characters_ids, 'Characters'
       %td.even
         = collection_check_boxes :template, :character_ids, @selectable_characters, :id, :name, selected: @character_ids do |box|
-          = box.check_box
-          = box.label
+          = box.check_box class: 'vmid'
+          = box.label class: 'vmid'
           %br
 %tfoot
   %tr

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -14,10 +14,10 @@
         %th.sub Notifications
         %td{class: cycle('even', 'odd')}
           = f.check_box :email_notifications, class: 'width-15 vmid'
-          = f.label :email_notifications, "Email about new tags"
+          = f.label :email_notifications, "Email about new tags", class: 'vmid'
           %br
           = f.check_box :favorite_notifications, class: 'width-15 vmid'
-          = f.label :favorite_notifications, 'Notify when a favorited author makes a new post'
+          = f.label :favorite_notifications, 'Notify when a favorited author makes a new post', class: 'vmid'
       - unless current_user.avatar.present?
         %tr
           %th.sub Avatar
@@ -33,7 +33,7 @@
         %th.sub Split icon picker
         %td{class: cycle('even', 'odd')}
           = f.check_box :icon_picker_grouping, class: 'width-15 vmid'
-          = f.label :icon_picker_grouping, "Group the icon picker by gallery"
+          = f.label :icon_picker_grouping, "Group the icon picker by gallery", class: 'vmid'
       %tr
         %th.sub Default view
         %td{class: cycle('even', 'odd')}
@@ -42,7 +42,7 @@
           = f.select(:default_character_split, options_for_select({ 'Group characters page by template': 'template', 'Do not group characters page': 'none' }, current_user.default_character_split))
           %br
           = f.check_box :default_hide_retired_characters, class: 'width-15 vmid'
-          = f.label :default_hide_retired_characters, "Hide retired characters"
+          = f.label :default_hide_retired_characters, "Hide retired characters", class: 'vmid'
       %tr
         %th.sub= f.label :default_editor
         - editor_modes = { 'Rich Text': 'rtf', HTML: 'html', Markdown: 'md' }
@@ -65,33 +65,33 @@
         %th.sub Unread
         %td{class: cycle('even', 'odd')}
           = f.check_box :unread_opened, class: 'width-15 vmid'
-          = f.label :unread_opened, "Display opened threads only"
+          = f.label :unread_opened, "Display opened threads only", class: 'vmid'
           %br
           = f.check_box :visible_unread, class: 'width-15 vmid'
-          = f.label :visible_unread, "Outline when jumping to unread"
+          = f.label :visible_unread, "Outline when jumping to unread", class: 'vmid'
           %br
           = f.check_box :hide_from_all, class: 'width-15 vmid'
-          = f.label :hide_from_all, "Hide hidden posts from recently updated and other post lists"
+          = f.label :hide_from_all, "Hide hidden posts from recently updated and other post lists", class: 'vmid'
       %tr
         %th.sub Daily Report
         %td{class: cycle('even', 'odd')}
           = f.check_box :ignore_unread_daily_report, class: 'width-15 vmid'
-          = f.label :ignore_unread_daily_report, "Hide unread notice"
+          = f.label :ignore_unread_daily_report, "Hide unread notice", class: 'vmid'
       %tr
         %th.sub Warnings
         %td{class: cycle('even', 'odd')}
           = f.check_box :hide_warnings, class: 'width-15 vmid'
-          = f.label :hide_warnings, "Hide content warnings"
+          = f.label :hide_warnings, "Hide content warnings", class: 'vmid'
       %tr
         %th.sub Replies Owed
         %td{class: cycle('even', 'odd')}
           = f.check_box :hide_hiatused_tags_owed, class: 'width-15 vmid'
-          = f.label :hide_hiatused_tags_owed, "Hide hiatused threads"
+          = f.label :hide_hiatused_tags_owed, "Hide hiatused threads", class: 'vmid'
       %tr
         %th.sub Character Quick Switcher
         %td{class: cycle('even', 'odd')}
           = f.check_box :show_user_in_switcher, class: 'width-15 vmid'
-          = f.label :show_user_in_switcher, "Show user character"
+          = f.label :show_user_in_switcher, "Show user character", class: 'vmid'
     %tfoot
       %tr
         %th.form-table-ender{colspan: 2}= submit_tag "Save", class: 'button'

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -44,7 +44,7 @@
         %th.sub.vtop Terms
         %td.odd
           = check_box_tag :tos, true, params[:tos].present?
-          = label_tag :tos do
+          = label_tag :tos, class: 'vmid' do
             I have read and agree to the
             = link_to 'Terms of Service', tos_path
             and the


### PR DESCRIPTION
Examples:

Before:
![image](https://github.com/user-attachments/assets/bfffd2e6-2424-4e3b-b0b8-ecfa58f0f2c2)
After:
![image](https://github.com/user-attachments/assets/31f9bd63-e660-4b85-9b97-97f43a48b5a5)


Before:
![image](https://github.com/user-attachments/assets/2144c249-3a6b-45e5-886e-01294a470c21)
After:
![image](https://github.com/user-attachments/assets/d7a70cc3-2366-463a-a3aa-0879382d8e51)

Before:
![image](https://github.com/user-attachments/assets/245fd525-f313-4225-96ff-66e53c3eb11c)
After:
![image](https://github.com/user-attachments/assets/68f4b964-96c7-4f87-b9b2-457a156c30cd)
