### PR TITLE
Turn off yjit to see memory impact

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -80,5 +80,9 @@ module Glowfic
     # redis-rails does not support cache versioning
     config.active_record.cache_versioning = false
     config.active_record.collection_cache_versioning = false
+
+    # Setting enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. We are
+    # deploying to a memory constrained environment so we set this to `false`.
+    Rails.application.config.yjit = false
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,6 @@ module Glowfic
 
     # Setting enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. We are
     # deploying to a memory constrained environment so we set this to `false`.
-    Rails.application.config.yjit = false
+    config.yjit = false
   end
 end


### PR DESCRIPTION
Per the Rails 7.2 settings file:
```
# Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
# deploying to a memory constrained environment you may want to set this to `false`.
#++
# Rails.application.config.yjit = true
```

And Heroku is in fact memory constrained, and we did in fact see a memory spike after deploy:

![image](https://github.com/user-attachments/assets/473c4101-b3e2-4f6c-ad47-31129901a3b8)

So turning off to see if this helps.