### PR TITLE
Enable frozen_string_literal in ActionView Templates

### DIFF
--- a/config/initializers/template_frozen_literal.rb
+++ b/config/initializers/template_frozen_literal.rb
@@ -1,0 +1,3 @@
+# reduce memory use of strings in ActionView Templates
+# https://github.com/rails/rails/blob/v7.2.2/actionview/lib/action_view/template.rb#L181
+ActionView::Template.frozen_string_literal = true


### PR DESCRIPTION
Goal is to reduce memory use of strings in ActionView Templates

https://github.com/rails/rails/blob/v7.2.2/actionview/lib/action_view/template.rb#L181