### PR TITLE
Use inline-grid display for #holder #content

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -123,7 +123,13 @@
 }
 
 @media (max-width: 600px) {
-  #holder { display: inline-block; }
+  #holder {
+    display: inline-block;
+
+    #content {
+      display: inline-grid;
+    }
+  }
 }
 
 #content, #tos {


### PR DESCRIPTION
Fixes the issue introduced by https://github.com/glowfic-constellation/glowfic/pull/2338 with replies with nonstandard widths (such as e.g. a very long "AAAA" on a single line).