### PR TITLE
Fix display issues

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -120,6 +120,10 @@
 #holder {
   min-height: 100%;
   position: relative;
+
+  #content {
+    width: 100%;
+  }
 }
 
 @media (max-width: 600px) {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -132,6 +132,9 @@
   }
 }
 
+.profile-table-cell { max-width: 0; }
+.profile-table-cell .padding-10 { overflow-x: scroll; }
+
 #content, #tos {
   padding: 20px;
   font-size: $font_size_main;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -134,6 +134,9 @@
 
 .profile-table-cell { max-width: 0; }
 .profile-table-cell .padding-10 { overflow-x: scroll; }
+@media (max-width: 600px) {
+  .recent-posts { width: 100% !important; }
+}
 
 #content, #tos {
   padding: 20px;

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -21,130 +21,131 @@
   - else
     %b Info
 
-%table.left-info-box.character-info-box
-  %thead
-    %tr
-      %th.info-box-header
-        %span.character-name= @character.name
-        - if @character.screenname
-          %br
-          %span.character-screenname= breakable_text(@character.screenname)
-        - if @character.npc?
-          %br
-          %span.character-is-npc (NPC)
-  %tbody
-    - if @character.default_icon
-      %tr
-        %td.character-icon.icons-box
-          = link_to icon_path(@character.default_icon) do
-            = icon_tag @character.default_icon
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to @character do
-          = image_tag "icons/chart_bar.png", alt: ''
-          Info
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to character_path(@character, view: 'galleries') do
-          = image_tag "icons/photos.png", alt: ''
-          Galleries
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to character_path(@character, view: 'posts') do
-          = image_tag "icons/book_open.png", alt: ''
-          Posts
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to search_replies_path(commit: true, character_id: @character.id, sort: :created_new) do
-          = image_tag "icons/table_multiple.png", alt: ''
-          Replies
-    - if @character.editable_by?(current_user)
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to edit_character_path(@character), class: 'character-edit' do
-            = image_tag "icons/pencil.png", alt: ''
-            Edit Character
-    - if logged_in? && @character.user_id == current_user.id
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to duplicate_character_path(@character), method: :post, class: 'character-duplicate', data: { confirm: 'Are you sure you want to duplicate this character?' } do
-            = image_tag "icons/arrow_branch.png", alt: ''
-            Duplicate Character
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to replace_character_path(@character), class: 'character-replace' do
-            = image_tag "icons/swap.png", style: 'width: 16px;', alt: ''
-            Replace Character
-    - if @character.deletable_by?(current_user)
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to @character, method: :delete, class: 'character-delete', data: { confirm: 'Are you sure you want to delete this character?' } do
-            = image_tag "icons/cross.png", alt: ''
-            Delete Character
-
-- if params[:view] == 'galleries'
-  - galleries = @character.galleries.select('galleries.*').with_gallery_groups.ordered
-  %table.character-right-content-box#reorder-galleries-table
+%div
+  %table.left-info-box.character-info-box
     %thead
       %tr
-        %th.table-title
-          Galleries
-          .loading.float-right.hidden= loading_tag
-          .saveerror.float-right.hidden
-            = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
-            Error, please refresh
-          .saveconf.float-right.hidden
-            = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
-            Saved
-    - galleries.each do |gallery|
-      = render 'galleries/single', gallery: gallery, klass: 'subber', skip_forms: true, character_gallery: gallery.character_gallery_for(@character), is_owner: @character.user == current_user
-    - unless galleries.present?
-      %tbody
-        %tr
-          %td.icon-box
-            .centered.padding-5 — No galleries yet —
-- elsif params[:view] == 'posts'
-  - content_for(:posts_title) { 'Recent Threads' }
-  = render 'posts/list', posts: @posts, table_class: 'character-right-content-box'
-- else
-  - reset_cycle
-  %table.character-right-content-box
-    %thead
-      %tr
-        %th.table-title{colspan: 2} Info
+        %th.info-box-header
+          %span.character-name= @character.name
+          - if @character.screenname
+            %br
+            %span.character-screenname= breakable_text(@character.screenname)
+          - if @character.npc?
+            %br
+            %span.character-is-npc (NPC)
     %tbody
-      - if @character.nickname.present?
+      - if @character.default_icon
         %tr
-          %th.sub.vtop.width-150
-            - if @character.npc?
-              Original post
-            - else
-              Nickname
-          %td.character-nickname{class: cycle('even', 'odd')}= @character.nickname
-      - aliases = @character.aliases.ordered.pluck(:name)
-      - if aliases.present?
+          %td.character-icon.icons-box
+            = link_to icon_path(@character.default_icon) do
+              = icon_tag @character.default_icon
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to @character do
+            = image_tag "icons/chart_bar.png", alt: ''
+            Info
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to character_path(@character, view: 'galleries') do
+            = image_tag "icons/photos.png", alt: ''
+            Galleries
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to character_path(@character, view: 'posts') do
+            = image_tag "icons/book_open.png", alt: ''
+            Posts
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to search_replies_path(commit: true, character_id: @character.id, sort: :created_new) do
+            = image_tag "icons/table_multiple.png", alt: ''
+            Replies
+      - if @character.editable_by?(current_user)
         %tr
-          %th.sub.vtop.width-150 Aliases
-          %td.character-aliases{class: cycle('even', 'odd')}= aliases.join(", ")
-      - if @character.template
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to edit_character_path(@character), class: 'character-edit' do
+              = image_tag "icons/pencil.png", alt: ''
+              Edit Character
+      - if logged_in? && @character.user_id == current_user.id
         %tr
-          %th.sub.vtop.width-150 Template
-          %td.character-template{class: cycle('even', 'odd')}
-            = link_to @character.template.name, template_path(@character.template), class: 'character-template'
-      - if @character.cluster
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to duplicate_character_path(@character), method: :post, class: 'character-duplicate', data: { confirm: 'Are you sure you want to duplicate this character?' } do
+              = image_tag "icons/arrow_branch.png", alt: ''
+              Duplicate Character
         %tr
-          %th.sub.vtop.width-150
-          %td.character-cluster{class: cycle('even', 'odd')}= @character.cluster
-      - if @character.pb?
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to replace_character_path(@character), class: 'character-replace' do
+              = image_tag "icons/swap.png", style: 'width: 16px;', alt: ''
+              Replace Character
+      - if @character.deletable_by?(current_user)
         %tr
-          %th.sub.vtop.width-150 Facecast
-          %td.character-pb{class: cycle('even', 'odd')}= @character.pb
-      - if @character.settings.present?
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to @character, method: :delete, class: 'character-delete', data: { confirm: 'Are you sure you want to delete this character?' } do
+              = image_tag "icons/cross.png", alt: ''
+              Delete Character
+
+  - if params[:view] == 'galleries'
+    - galleries = @character.galleries.select('galleries.*').with_gallery_groups.ordered
+    %table.character-right-content-box#reorder-galleries-table
+      %thead
         %tr
-          %th.sub.vtop.width-150 Setting
-          - setting_links = @character.settings.map { |setting| link_to(setting.name, tag_path(setting)) }
-          %td.character-setting{class: cycle('even', 'odd')}= safe_join(setting_links, ', ')
-      - if @character.description
+          %th.table-title
+            Galleries
+            .loading.float-right.hidden= loading_tag
+            .saveerror.float-right.hidden
+              = image_tag "icons/exclamation.png", title: 'Error', class: 'vmid', alt: '!'
+              Error, please refresh
+            .saveconf.float-right.hidden
+              = image_tag "icons/accept.png", title: 'Saved', class: 'vmid', alt: ''
+              Saved
+      - galleries.each do |gallery|
+        = render 'galleries/single', gallery: gallery, klass: 'subber', skip_forms: true, character_gallery: gallery.character_gallery_for(@character), is_owner: @character.user == current_user
+      - unless galleries.present?
+        %tbody
+          %tr
+            %td.icon-box
+              .centered.padding-5 — No galleries yet —
+  - elsif params[:view] == 'posts'
+    - content_for(:posts_title) { 'Recent Threads' }
+    = render 'posts/list', posts: @posts, table_class: 'character-right-content-box'
+  - else
+    - reset_cycle
+    %table.character-right-content-box
+      %thead
         %tr
-          %th.sub.vtop.width-150 Description
-          %td.character-description.written-content{class: cycle('even', 'odd')}= sanitize_written_content(@character.description)
+          %th.table-title{colspan: 2} Info
+      %tbody
+        - if @character.nickname.present?
+          %tr
+            %th.sub.vtop.width-150
+              - if @character.npc?
+                Original post
+              - else
+                Nickname
+            %td.character-nickname{class: cycle('even', 'odd')}= @character.nickname
+        - aliases = @character.aliases.ordered.pluck(:name)
+        - if aliases.present?
+          %tr
+            %th.sub.vtop.width-150 Aliases
+            %td.character-aliases{class: cycle('even', 'odd')}= aliases.join(", ")
+        - if @character.template
+          %tr
+            %th.sub.vtop.width-150 Template
+            %td.character-template{class: cycle('even', 'odd')}
+              = link_to @character.template.name, template_path(@character.template), class: 'character-template'
+        - if @character.cluster
+          %tr
+            %th.sub.vtop.width-150
+            %td.character-cluster{class: cycle('even', 'odd')}= @character.cluster
+        - if @character.pb?
+          %tr
+            %th.sub.vtop.width-150 Facecast
+            %td.character-pb{class: cycle('even', 'odd')}= @character.pb
+        - if @character.settings.present?
+          %tr
+            %th.sub.vtop.width-150 Setting
+            - setting_links = @character.settings.map { |setting| link_to(setting.name, tag_path(setting)) }
+            %td.character-setting{class: cycle('even', 'odd')}= safe_join(setting_links, ', ')
+        - if @character.description
+          %tr
+            %th.sub.vtop.width-150 Description
+            %td.character-description.written-content{class: cycle('even', 'odd')}= sanitize_written_content(@character.description)

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -21,81 +21,83 @@
   - else
     %b Stats
 
-%table.left-info-box.icon-info-box
-  %tr
-    %th.info-box-header.icon-keyword= @icon.keyword
-  %tr
-    %td.icons-box.centered.icon-icon= icon_tag @icon
-  - if @icon.credit
-    %tr
-      %td.icon-credit
-        .details= sanitize_simple_link_text(@icon.credit)
-  %tr
-    %td.centered{class: cycle('even', 'odd')}
-      = link_to icon_path(@icon, view: 'stats') do
-        = image_tag "icons/chart_bar.png", alt: ''
-        Stats
-  %tr
-    %td.centered{class: cycle('even', 'odd')}
-      = link_to icon_path(@icon, view: 'galleries') do
-        = image_tag "icons/photos.png", alt: ''
-        &nbsp;Galleries
-  %tr
-    %td.centered{class: cycle('even', 'odd')}
-      = link_to icon_path(@icon, view: 'posts') do
-        = image_tag "icons/book_open.png", alt: ''
-        Posts
-  %tr
-    %td.centered{class: cycle('even', 'odd')}
-      = link_to search_replies_path(commit: true, icon_id: @icon.id, sort: :created_new) do
-        = image_tag "icons/table_multiple.png", alt: ''
-        Replies
-  - if @icon.user_id == current_user.try(:id)
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to edit_icon_path(@icon) do
-          = image_tag "icons/pencil.png", alt: ''
-          Edit Icon
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to avatar_icon_path(@icon), method: :post do
-          = image_tag "icons/status_online.png", alt: ''
-          Make Avatar
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to replace_icon_path(@icon) do
-          = image_tag "icons/swap.png", style: 'width: 16px;', alt: ''
-          Replace Icon
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to @icon, method: :delete, data: { confirm: 'Are you sure you want to delete this icon?' } do
-          = image_tag "icons/cross.png", alt: ''
-          Delete Icon
 
-- if params[:view] == 'galleries'
-  %table.icon-right-content-box
-    %thead
+%div
+  %table.left-info-box.icon-info-box
+    %tr
+      %th.info-box-header.icon-keyword= @icon.keyword
+    %tr
+      %td.icons-box.centered.icon-icon= icon_tag @icon
+    - if @icon.credit
       %tr
-        %th.table-title Galleries
-    - if @galleries.present?
-      = render partial: 'galleries/single', collection: @galleries, as: :gallery, locals: { klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user }
-    - else
+        %td.icon-credit
+          .details= sanitize_simple_link_text(@icon.credit)
+    %tr
+      %td.centered{class: cycle('even', 'odd')}
+        = link_to icon_path(@icon, view: 'stats') do
+          = image_tag "icons/chart_bar.png", alt: ''
+          Stats
+    %tr
+      %td.centered{class: cycle('even', 'odd')}
+        = link_to icon_path(@icon, view: 'galleries') do
+          = image_tag "icons/photos.png", alt: ''
+          &nbsp;Galleries
+    %tr
+      %td.centered{class: cycle('even', 'odd')}
+        = link_to icon_path(@icon, view: 'posts') do
+          = image_tag "icons/book_open.png", alt: ''
+          Posts
+    %tr
+      %td.centered{class: cycle('even', 'odd')}
+        = link_to search_replies_path(commit: true, icon_id: @icon.id, sort: :created_new) do
+          = image_tag "icons/table_multiple.png", alt: ''
+          Replies
+    - if @icon.user_id == current_user.try(:id)
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to edit_icon_path(@icon) do
+            = image_tag "icons/pencil.png", alt: ''
+            Edit Icon
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to avatar_icon_path(@icon), method: :post do
+            = image_tag "icons/status_online.png", alt: ''
+            Make Avatar
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to replace_icon_path(@icon) do
+            = image_tag "icons/swap.png", style: 'width: 16px;', alt: ''
+            Replace Icon
+      %tr
+        %td.centered{class: cycle('even', 'odd')}
+          = link_to @icon, method: :delete, data: { confirm: 'Are you sure you want to delete this icon?' } do
+            = image_tag "icons/cross.png", alt: ''
+            Delete Icon
+
+  - if params[:view] == 'galleries'
+    %table.icon-right-content-box
+      %thead
+        %tr
+          %th.table-title Galleries
+      - if @galleries.present?
+        = render partial: 'galleries/single', collection: @galleries, as: :gallery, locals: { klass: 'subber', skip_forms: true, is_owner: @icon.user == current_user }
+      - else
+        %tbody
+          %tr
+            %td.even.centered — No galleries yet —
+  - elsif params[:view] == 'posts'
+    - content_for :posts_title do
+      Posts Containing Icon
+    = render 'posts/list', posts: @posts, table_class: 'icon-right-content-box'
+  - else
+    %table.icon-right-content-box
+      %thead
+        %tr
+          %th.table-title{colspan: 2} Stats
       %tbody
         %tr
-          %td.even.centered — No galleries yet —
-- elsif params[:view] == 'posts'
-  - content_for :posts_title do
-    Posts Containing Icon
-  = render 'posts/list', posts: @posts, table_class: 'icon-right-content-box'
-- else
-  %table.icon-right-content-box
-    %thead
-      %tr
-        %th.table-title{colspan: 2} Stats
-    %tbody
-      %tr
-        %th.sub.width-150 Times Used
-        %td.even= @times_used.to_s
-      %tr
-        %th.sub.width-150 Posts In
-        %td.even= @posts_used
+          %th.sub.width-150 Times Used
+          %td.even= @times_used.to_s
+        %tr
+          %th.sub.width-150 Posts In
+          %td.even= @posts_used

--- a/app/views/messages/index.haml
+++ b/app/views/messages/index.haml
@@ -12,7 +12,7 @@
     %tbody
       - if @messages.empty?
         %tr
-          %td.centered.padding-10 — No messages yet —
+          %td.centered.padding-10.even — No messages yet —
       - else
         - @messages.each do |message|
           %tr.message-row

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -5,58 +5,59 @@
   &raquo;
   %b= @tag.name
 
-%table.left-info-box.tag-info-box
-  %thead
-    %tr
-      %th.info-box-header
-        %span.character-name #{@tag.type.titlecase}: #{@tag.name}
-  %tbody
-    %tr
-      %td.centered{class: cycle('even', 'odd')}
-        = link_to tag_path(@tag) do
-          = image_tag "icons/chart_bar.png", class: 'vmid', alt: ''
-          Info
-    - if @tag.is_a?(GalleryGroup)
+%div
+  %table.left-info-box.tag-info-box
+    %thead
+      %tr
+        %th.info-box-header
+          %span.character-name #{@tag.type.titlecase}: #{@tag.name}
+    %tbody
       %tr
         %td.centered{class: cycle('even', 'odd')}
-          = link_to tag_path(@tag, view: 'galleries') do
-            = image_tag "icons/photos.png", class: 'vmid', alt: ''
-            Galleries
-    - else
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to tag_path(@tag, view: 'posts') do
-            = image_tag "icons/book_open.png", class: 'vmid', alt: ''
-            Posts
-    - if @tag.is_a?(Setting) || @tag.is_a?(GalleryGroup)
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to tag_path(@tag, view: 'characters') do
-            = image_tag "icons/group.png", class: 'vmid', alt: ''
-            Characters
-    - if @tag.is_a?(ContentWarning)
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to tag_path(@tag, view: 'users') do
-            = image_tag "icons/group.png", class: 'vmid', alt: ''
-            Users
-    - if @tag.is_a?(Setting) && @tag.child_settings.present?
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to tag_path(@tag, view: 'settings') do
-            = image_tag "icons/world.png", class: 'vmid', alt: ''
-            Settings
-    - if @tag.editable_by?(current_user)
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to edit_tag_path(@tag) do
-            = image_tag "icons/pencil.png", class: 'vmid', alt: ''
-            Edit #{@tag.type.titlecase}
-    - if @tag.deletable_by?(current_user)
-      %tr
-        %td.centered{class: cycle('even', 'odd')}
-          = link_to tag_path(@tag), method: :delete, data: { confirm: 'Are you sure you want to delete this tag?' } do
-            = image_tag "icons/cross.png", class: 'vmid', alt: ''
-            Delete #{@tag.type.titlecase}
+          = link_to tag_path(@tag) do
+            = image_tag "icons/chart_bar.png", class: 'vmid', alt: ''
+            Info
+      - if @tag.is_a?(GalleryGroup)
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to tag_path(@tag, view: 'galleries') do
+              = image_tag "icons/photos.png", class: 'vmid', alt: ''
+              Galleries
+      - else
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to tag_path(@tag, view: 'posts') do
+              = image_tag "icons/book_open.png", class: 'vmid', alt: ''
+              Posts
+      - if @tag.is_a?(Setting) || @tag.is_a?(GalleryGroup)
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to tag_path(@tag, view: 'characters') do
+              = image_tag "icons/group.png", class: 'vmid', alt: ''
+              Characters
+      - if @tag.is_a?(ContentWarning)
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to tag_path(@tag, view: 'users') do
+              = image_tag "icons/group.png", class: 'vmid', alt: ''
+              Users
+      - if @tag.is_a?(Setting) && @tag.child_settings.present?
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to tag_path(@tag, view: 'settings') do
+              = image_tag "icons/world.png", class: 'vmid', alt: ''
+              Settings
+      - if @tag.editable_by?(current_user)
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to edit_tag_path(@tag) do
+              = image_tag "icons/pencil.png", class: 'vmid', alt: ''
+              Edit #{@tag.type.titlecase}
+      - if @tag.deletable_by?(current_user)
+        %tr
+          %td.centered{class: cycle('even', 'odd')}
+            = link_to tag_path(@tag), method: :delete, data: { confirm: 'Are you sure you want to delete this tag?' } do
+              = image_tag "icons/cross.png", class: 'vmid', alt: ''
+              Delete #{@tag.type.titlecase}
 
-= render @view
+  = render @view

--- a/app/views/users/profile_edit.haml
+++ b/app/views/users/profile_edit.haml
@@ -3,36 +3,37 @@
   &raquo;
   %b Edit Profile
 
-= render 'infobox', user: current_user
+%span
+  = render 'infobox', user: current_user
 
-.content-header.user-right-content-box Edit profile
-#post-editor.margin-left-200
-  = form_for current_user, html: { id: 'post_form' } do |f|
-    %table
-      %tbody
-        %tr
-          %th.sub.width-15.vtop= f.label :profile, "Description"
-          %td{class: cycle('even', 'odd')}
-            %button.view-button#rtf{type: 'button', class: ('selected' if current_user.profile_editor_mode == 'rtf')} Rich Text
-            %button.view-button#md{type: 'button', class: ('selected' if current_user.profile_editor_mode == 'md')} Markdown
-            %button.view-button#html{type: 'button', class: ('selected' if current_user.profile_editor_mode == 'html')} HTML
-            %button.view-button#editor-help{type: 'button', title: 'Help'} ?
-            %br
-            %br
-            = f.hidden_field :profile_editor_mode, id: 'profile_editor_mode'
-            #post-form-wrapper.no-margin-left
-              = f.text_area :profile, class: 'tinymce'
-            = render 'posts/editor_help', editor_location: 'profile'
-        %tr
-          %th.sub.vtop= f.label :moiety, "Moiety hex"
-          %td{class: cycle('even', 'odd')}
-            \#
-            = f.text_field :moiety, placeholder: "Hex code", class: 'text', style: 'width: 80px;', maxlength: 6
-        %tr
-          %th.sub.vtop= f.label :moiety_name, "Moiety name"
-          %td{class: cycle('even', 'odd')}= f.text_field :moiety_name, placeholder: "Moiety", class: 'text'
-        %tr
-          %th.sub= f.label :content_warning_ids, "Author warnings"
-          %td{class: cycle('even', 'odd')}= tag_select(current_user, f, :content_warnings)
-    %br
-    = submit_tag 'Save', class: 'button', id: 'submit_button', name: 'button_submit_profile', data: { disable_with: 'Saving...' }
+  .content-header.user-right-content-box Edit profile
+  #post-editor.margin-left-200
+    = form_for current_user, html: { id: 'post_form' } do |f|
+      %table
+        %tbody
+          %tr
+            %th.sub.width-15.vtop= f.label :profile, "Description"
+            %td{class: cycle('even', 'odd')}
+              %button.view-button#rtf{type: 'button', class: ('selected' if current_user.profile_editor_mode == 'rtf')} Rich Text
+              %button.view-button#md{type: 'button', class: ('selected' if current_user.profile_editor_mode == 'md')} Markdown
+              %button.view-button#html{type: 'button', class: ('selected' if current_user.profile_editor_mode == 'html')} HTML
+              %button.view-button#editor-help{type: 'button', title: 'Help'} ?
+              %br
+              %br
+              = f.hidden_field :profile_editor_mode, id: 'profile_editor_mode'
+              #post-form-wrapper.no-margin-left
+                = f.text_area :profile, class: 'tinymce'
+              = render 'posts/editor_help', editor_location: 'profile'
+          %tr
+            %th.sub.vtop= f.label :moiety, "Moiety hex"
+            %td{class: cycle('even', 'odd')}
+              \#
+              = f.text_field :moiety, placeholder: "Hex code", class: 'text', style: 'width: 80px;', maxlength: 6
+          %tr
+            %th.sub.vtop= f.label :moiety_name, "Moiety name"
+            %td{class: cycle('even', 'odd')}= f.text_field :moiety_name, placeholder: "Moiety", class: 'text'
+          %tr
+            %th.sub= f.label :content_warning_ids, "Author warnings"
+            %td{class: cycle('even', 'odd')}= tag_select(current_user, f, :content_warnings)
+      %br
+      = submit_tag 'Save', class: 'button', id: 'submit_button', name: 'button_submit_profile', data: { disable_with: 'Saving...' }

--- a/app/views/users/profile_edit.haml
+++ b/app/views/users/profile_edit.haml
@@ -3,7 +3,7 @@
   &raquo;
   %b Edit Profile
 
-%span
+%div
   = render 'infobox', user: current_user
 
   .content-header.user-right-content-box Edit profile

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -1,6 +1,6 @@
 = render 'warnings', user: @user
 
-%span
+%div
   = render 'infobox', user: @user
 
   - is_current_user = @user.id == current_user.try(:id)

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -26,4 +26,4 @@
 
   - content_for :posts_title do
     #{@user.username}'s Recent Posts
-  = render 'posts/list', posts: @posts, table_class: 'user-right-content-box'
+  = render 'posts/list', posts: @posts, table_class: 'user-right-content-box recent-posts'

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -1,27 +1,29 @@
 = render 'warnings', user: @user
-= render 'infobox', user: @user
 
-- is_current_user = @user.id == current_user.try(:id)
-- has_profile = @user.profile.present?
-- if has_profile || is_current_user
-  %table.user-right-content-box
-    %thead
-      %tr
-        %th.table-title
-          Author Profile
-          - if is_current_user
-            = link_to profile_edit_user_path(@user) do
-              = image_tag "icons/pencil.png".freeze, title: 'Edit'.freeze, alt: 'Edit'.freeze
-    %tbody
-      %tr
-        %td
-          .auto.profile.written-content
-            .padding-10
-              - if has_profile
-                = sanitize_written_content(@user.profile.to_s, @user.profile_editor_mode)
-              - else
-                %em (Your profile is empty.)
+%span
+  = render 'infobox', user: @user
 
-- content_for :posts_title do
-  #{@user.username}'s Recent Posts
-= render 'posts/list', posts: @posts, table_class: 'user-right-content-box'
+  - is_current_user = @user.id == current_user.try(:id)
+  - has_profile = @user.profile.present?
+  - if has_profile || is_current_user
+    %table.user-right-content-box
+      %thead
+        %tr
+          %th.table-title
+            Author Profile
+            - if is_current_user
+              = link_to profile_edit_user_path(@user) do
+                = image_tag "icons/pencil.png".freeze, title: 'Edit'.freeze, alt: 'Edit'.freeze
+      %tbody
+        %tr
+          %td.profile-table-cell
+            .auto.profile.written-content
+              .padding-10
+                - if has_profile
+                  .post-content= sanitize_written_content(@user.profile.to_s, @user.profile_editor_mode)
+                - else
+                  %em (Your profile is empty.)
+
+  - content_for :posts_title do
+    #{@user.username}'s Recent Posts
+  = render 'posts/list', posts: @posts, table_class: 'user-right-content-box'


### PR DESCRIPTION
Fix various issues with the display of pages:

- Profiles were getting fucky with very long non-breaking lines.
- Pages using `.left-info-box` were placing their right side below the box on mobile.
- Various pages on mobile were not occupying the whole width of the screen.
- The inbox page was missing formatting when there were no inbox messages.