### PR TITLE
Turn profile horizontal scroll to auto rather than scroll

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -137,7 +137,7 @@
 }
 
 .profile-table-cell { max-width: 0; }
-.profile-table-cell .padding-10 { overflow-x: scroll; }
+.profile-table-cell .padding-10 { overflow-x: auto; }
 @media (max-width: 600px) {
   .recent-posts { width: 100% !important; }
 }


### PR DESCRIPTION
Latest update adds an ugly horizontal scroll to profiles. Fixing that.

![image](https://github.com/user-attachments/assets/f7c20f1c-d4d6-4cb7-b357-872940bc3592)
![image](https://github.com/user-attachments/assets/b92b301b-9a24-4990-9451-99fc8cfeb171)
![image](https://github.com/user-attachments/assets/2a33bc52-00c3-449a-a55b-cac9cc30aa2f)
