### PR TITLE
Explicitly disable asset compilation in prod (again)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,6 +16,9 @@ Rails.application.configure do
   config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
+  # Do not fall back to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Turn on fragment caching in view templates.
   config.action_controller.perform_caching = true
 


### PR DESCRIPTION
Rails 8 defaults remove this line from environments/production.rb, but its default isn't disabled: it's still enabled. Since we have a CDN, this shouldn't affect us much either way(?) but Heroku warns on it.