### PR TITLE
Add bundle install before Docker commands

### DIFF
--- a/bin-docker/rails
+++ b/bin-docker/rails
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose run --rm web bin/rails $@
+docker compose run --rm web bin/with-bundle bin/rails "$@"

--- a/bin-docker/rake
+++ b/bin-docker/rake
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose run --rm web rake "$@"
+docker compose run --rm web bin/with-bundle rake "$@"

--- a/bin-docker/record_examples
+++ b/bin-docker/record_examples
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose run --rm -e "APIPIE_RECORD=examples" web bundle exec rspec spec/controllers/api
+docker compose run --rm -e "APIPIE_RECORD=examples" web bin/with-bundle rspec spec/controllers/api

--- a/bin-docker/rspec
+++ b/bin-docker/rspec
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose run --rm web bundle exec rspec "$@"
+docker compose run --rm web bin/with-bundle rspec "$@"

--- a/bin-docker/runner
+++ b/bin-docker/runner
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose run --rm web "$@"
+docker compose run --rm web bin/with-bundle "$@"

--- a/bin/with-bundle
+++ b/bin/with-bundle
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+if ! bundle check > /dev/null; then
+  echo "Bundle gems changed, updating from Gemfile.lock!"
+  BUNDLE_FROZEN=true bundle install || { echo "Gemfile doesn't match Gemfile.lock, exiting - please run bundle install to force an update."; exit 1; }
+fi
+
+bundle exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     <<: *svc
     ports:
       - 3000:3000
-    command: bin/rails s
+    command: bin/with-bundle bin/rails s
     environment:
       <<: *env
       BIND_HOST: 0.0.0.0
@@ -36,7 +36,7 @@ services:
       RAILS_DEVELOPMENT_HOSTS: web:3000
   worker:
     <<: *svc
-    command: bundle exec rake resque:work
+    command: bin/with-bundle rake resque:work
     environment:
       <<: *env
       TERM_CHILD: 1


### PR DESCRIPTION
Avoids issues having to repeatedly update bundle gems when running Docker commands on updated repo setups

In local setups without Docker, you can also run `bin/with-bundle bin/rails ...` and similar!

If all dependencies are installed, this just runs `bundle check` (with no output, successful status code) and then runs the command passed. If some dependencies aren't yet installed, it'll output something like the following:
```
The following gems are missing
 * nokogiri (1.18.1)
 * resque (2.7.0)
 * sanitize (7.0.0)
 * resque-heroku-signals (2.7.0)
 * tilt (2.5.0)
 * ffi (1.17.0)
 * redis-client (0.23.0)
 * google-protobuf (4.27.5)
Install missing gems with `bundle install`
Bundle gems changed, updating from Gemfile.lock!
Fetching gem metadata from https://rubygems.org/.........
Fetching tilt 2.5.0
Fetching nokogiri 1.18.1 (x86_64-linux-gnu)
Fetching ffi 1.17.0 (x86_64-linux-gnu)
Fetching google-protobuf 4.27.5 (x86_64-linux)
Fetching redis-client 0.23.0
Installing tilt 2.5.0
Installing ffi 1.17.0 (x86_64-linux-gnu)
Installing redis-client 0.23.0
Fetching resque 2.7.0
Installing google-protobuf 4.27.5 (x86_64-linux)
Installing resque 2.7.0
Fetching resque-heroku-signals 2.7.0
Installing resque-heroku-signals 2.7.0
Installing nokogiri 1.18.1 (x86_64-linux-gnu)
Fetching sanitize 7.0.0
Installing sanitize 7.0.0
Bundle complete! 74 Gemfile dependencies, 199 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```
before executing the command.

If you edit the Gemfile without running `bundle install` manually, we'll intentionally show an error that we can't install the frozen Gemfile.lock (to avoid unexpected updates when running commands):
```
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
Bundle gems changed, updating from Gemfile.lock!
The dependencies in your gemfile changed, but the lockfile can't be updated because frozen mode is set

You have added to the Gemfile:
* api-paginationa

You have deleted from the Gemfile:
* api-pagination

Run `bundle install` elsewhere and add the updated Gemfile to version control.
Gemfile doesn't match Gemfile.lock, exiting - please run bundle install to force an update.
```