### PR TITLE
Make editor show the correct user's characters on preview

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -304,6 +304,7 @@ class RepliesController < WritableController
 
     @page_title = @post.subject
 
+    @reply = @written # So that editor_setup shows the correct characters
     editor_setup
     render :preview
   end

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -5,7 +5,7 @@ class WritableController < ApplicationController
   def build_template_groups(user=nil)
     return unless logged_in?
     user ||= current_user
-    user = current_user if user.id != current_user.try(:id) && !current_user.mod? && !current_user.admin?
+    user = current_user if user.id != current_user.id && !current_user.mod? && !current_user.admin?
 
     faked = Struct.new(:name, :id, :plucked_characters)
     faked_npcs = Struct.new(:name, :id, :plucked_npcs)

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -5,7 +5,7 @@ class WritableController < ApplicationController
   def build_template_groups(user=nil)
     return unless logged_in?
     user ||= current_user
-    user = current_user if user.id != current_user.id && !current_user.mod? && !current_user.admin?
+    user = current_user unless user.id == current_user.id || current_user.has_permission?(:edit_posts)
 
     faked = Struct.new(:name, :id, :plucked_characters)
     faked_npcs = Struct.new(:name, :id, :plucked_npcs)

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -5,6 +5,7 @@ class WritableController < ApplicationController
   def build_template_groups(user=nil)
     return unless logged_in?
     user ||= current_user
+    user = current_user if user.id != current_user.try(:id) && !current_user.mod? && !current_user.admin?
 
     faked = Struct.new(:name, :id, :plucked_characters)
     faked_npcs = Struct.new(:name, :id, :plucked_npcs)

--- a/spec/controllers/replies/create_spec.rb
+++ b/spec/controllers/replies/create_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RepliesController, 'POST create' do
   context "preview" do
     it "takes correct actions" do
       user = create(:user)
-      reply_post = create(:post, user: user)
+      reply_post = create(:post)
       create(:reply, post: reply_post) # reply
       reply_post.mark_read(user)
       login_as(user)
@@ -45,7 +45,7 @@ RSpec.describe RepliesController, 'POST create' do
       expect(assigns(:page_title)).to eq(reply_post.subject)
       expect(assigns(:written)).to be_a_new_record
       expect(assigns(:written).post).to eq(reply_post)
-      expect(assigns(:written).user).to eq(reply_post.user)
+      expect(assigns(:written).user).to eq(user)
       expect(assigns(:written).content).to eq('example')
       expect(assigns(:written).character).to eq(char1)
       expect(assigns(:written).icon).to eq(icon)
@@ -55,7 +55,7 @@ RSpec.describe RepliesController, 'POST create' do
       draft = ReplyDraft.last
 
       expect(draft.post).to eq(reply_post)
-      expect(draft.user).to eq(reply_post.user)
+      expect(draft.user).to eq(user)
       expect(draft.content).to eq('example')
       expect(draft.character).to eq(char1)
       expect(draft.icon).to eq(icon)

--- a/spec/controllers/replies/update_spec.rb
+++ b/spec/controllers/replies/update_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe RepliesController, 'PUT update' do
     it "takes correct actions" do
       Reply.auditing_enabled = true
       user = create(:user)
-      reply_post = create(:post, user: user)
+      reply_post = create(:post)
       reply = create(:reply, post: reply_post, user: user)
       login_as(user)
       expect(ReplyDraft.count).to eq(0)
@@ -164,14 +164,14 @@ RSpec.describe RepliesController, 'PUT update' do
 
       written = assigns(:written)
       expect(written).not_to be_a_new_record
-      expect(written.user).to eq(reply_post.user)
+      expect(written.user).to eq(user)
       expect(written.character).to eq(char)
       expect(written.icon).to eq(icon)
       expect(written.character_alias).to eq(calias)
 
       # check it still remembers its current attributes, since this is a preview
       persisted = written.reload
-      expect(persisted.user).to eq(reply_post.user)
+      expect(persisted.user).to eq(user)
       expect(persisted.character).to be_nil
       expect(persisted.icon).to be_nil
       expect(persisted.character_alias).to be_nil

--- a/spec/controllers/writable_controller_spec.rb
+++ b/spec/controllers/writable_controller_spec.rb
@@ -160,28 +160,28 @@ RSpec.describe WritableController do
 
         char3 = create(:character, user: user, name: 'c')
         char1 = create(:character, user: user, name: 'a')
-        char2 = create(:character, user: user, name: 'b')
+        char2 = create(:character, name: 'b')
         npc3 = create(:character, user: user, name: 'npc_c', npc: true)
-        npc1 = create(:character, user: user, name: 'npc_a', npc: true)
+        npc1 = create(:character, name: 'npc_a', npc: true)
         npc2 = create(:character, user: user, name: 'npc_b', npc: true)
         create(:character, user: user)
-        post = create(:post, user: user, character: char2)
+        post = create(:post, user: char2.user, character: char2)
         create(:reply, post: post, user: user, character: char3)
         create(:reply, post: post, user: user, character: char1)
         create(:reply, post: post, user: user, character: npc2)
         create(:reply, post: post, user: user, character: npc3)
-        create(:reply, post: post, user: user, character: npc1)
+        create(:reply, post: post, user: npc1.user, character: npc1)
 
         controller.instance_variable_set(:@post, post)
         controller.send(:build_template_groups)
         templates = assigns(:templates)
         expect(templates.count).to eq(2) # thread chars, all chars
         expect(templates.first.name).to eq("Post characters")
-        expect(templates.first.plucked_characters.map(&:first)).to eq([char1, char2, char3].map(&:id))
+        expect(templates.first.plucked_characters.map(&:first)).to eq([char1, char3].map(&:id))
         npcs = assigns(:npcs)
         expect(npcs.count).to eq(2) # thread npcs, all npcs
         expect(npcs.first.name).to eq("Post NPCs")
-        expect(npcs.first.plucked_npcs.map(&:first)).to eq([npc1, npc2, npc3].map(&:id))
+        expect(npcs.first.plucked_npcs.map(&:first)).to eq([npc2, npc3].map(&:id))
       end
     end
 


### PR DESCRIPTION
When using the "preview" feature, the characters and NPCs that would show up to be selected would be the top poster's, not your own.

![image](https://github.com/user-attachments/assets/d13ebe57-65d1-42cb-b7d1-d16478fef1f8)
