### PR TITLE
Add rel=nofollow to view-param links

### DIFF
--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -31,11 +31,11 @@
           .link-box.action-new + New Template
       - else
         = @user.username + "'s #{obj_name}"
-      = link_to character_menu_link(view: 'icons'), class: 'view-button-link' do
+      = link_to character_menu_link(view: 'icons'), rel: 'nofollow', class: 'view-button-link' do
         .view-button{class: (:selected unless page_view == 'list')}
           = image_tag "icons/grid.png", class: 'icon-view', alt: ''
           Icons
-      = link_to character_menu_link(view: 'list'), class: 'view-button-link' do
+      = link_to character_menu_link(view: 'list'), rel: 'nofollow', class: 'view-button-link' do
         .view-button{class: (:selected if page_view == 'list')}
           = image_tag "icons/list.png", class: 'list-view', alt: ''
           List

--- a/app/views/characters/show.haml
+++ b/app/views/characters/show.haml
@@ -46,12 +46,12 @@
             Info
       %tr
         %td.centered{class: cycle('even', 'odd')}
-          = link_to character_path(@character, view: 'galleries') do
+          = link_to character_path(@character, view: 'galleries'), rel: 'nofollow' do
             = image_tag "icons/photos.png", alt: ''
             Galleries
       %tr
         %td.centered{class: cycle('even', 'odd')}
-          = link_to character_path(@character, view: 'posts') do
+          = link_to character_path(@character, view: 'posts'), rel: 'nofollow' do
             = image_tag "icons/book_open.png", alt: ''
             Posts
       %tr

--- a/app/views/galleries/_single.haml
+++ b/app/views/galleries/_single.haml
@@ -25,11 +25,11 @@
           = link_to gallery_path(gallery), method: :delete, data: { confirm: 'Are you sure you want to delete this gallery? (This will not delete the icons.)' }, class: 'gallery-delete' do
             .link-box.action-delete x Delete Gallery
       - if hide_minmax
-        = link_to url_for(view: 'icons'), class: 'view-button-link' do
+        = link_to url_for(view: 'icons'), rel: 'nofollow', class: 'view-button-link' do
           .view-button{class: (:selected unless page_view == 'list')}
             = image_tag "icons/grid.png", class: 'icon-view', alt: ''
             Icons
-        = link_to url_for(view: 'list'), class: 'view-button-link' do
+        = link_to url_for(view: 'list'), rel: 'nofollow', class: 'view-button-link' do
           .view-button{class: (:selected if page_view == 'list')}
             = image_tag "icons/list.png", class: 'list-view', alt: ''
             List

--- a/app/views/icons/show.haml
+++ b/app/views/icons/show.haml
@@ -10,7 +10,7 @@
   - if @galleries.present?
     = link_to @galleries.first.name, url_for(@galleries.first)
   - else
-    = link_to_if params[:view] != 'galleries', "(#{@icon.galleries.count} Galleries)", icon_path(@icon, view: 'galleries')
+    = link_to_if params[:view] != 'galleries', "(#{@icon.galleries.count} Galleries)", icon_path(@icon, view: 'galleries'), rel: 'nofollow'
   &raquo;
   = link_to_if params[:view].present?, @icon.keyword, @icon
   &raquo;
@@ -34,17 +34,17 @@
           .details= sanitize_simple_link_text(@icon.credit)
     %tr
       %td.centered{class: cycle('even', 'odd')}
-        = link_to icon_path(@icon, view: 'stats') do
+        = link_to icon_path(@icon, view: 'stats'), rel: 'nofollow' do
           = image_tag "icons/chart_bar.png", alt: ''
           Stats
     %tr
       %td.centered{class: cycle('even', 'odd')}
-        = link_to icon_path(@icon, view: 'galleries') do
+        = link_to icon_path(@icon, view: 'galleries'), rel: 'nofollow' do
           = image_tag "icons/photos.png", alt: ''
           &nbsp;Galleries
     %tr
       %td.centered{class: cycle('even', 'odd')}
-        = link_to icon_path(@icon, view: 'posts') do
+        = link_to icon_path(@icon, view: 'posts'), rel: 'nofollow' do
           = image_tag "icons/book_open.png", alt: ''
           Posts
     %tr

--- a/app/views/tags/show.haml
+++ b/app/views/tags/show.haml
@@ -20,31 +20,31 @@
       - if @tag.is_a?(GalleryGroup)
         %tr
           %td.centered{class: cycle('even', 'odd')}
-            = link_to tag_path(@tag, view: 'galleries') do
+            = link_to tag_path(@tag, view: 'galleries'), rel: 'nofollow' do
               = image_tag "icons/photos.png", class: 'vmid', alt: ''
               Galleries
       - else
         %tr
           %td.centered{class: cycle('even', 'odd')}
-            = link_to tag_path(@tag, view: 'posts') do
+            = link_to tag_path(@tag, view: 'posts'), rel: 'nofollow' do
               = image_tag "icons/book_open.png", class: 'vmid', alt: ''
               Posts
       - if @tag.is_a?(Setting) || @tag.is_a?(GalleryGroup)
         %tr
           %td.centered{class: cycle('even', 'odd')}
-            = link_to tag_path(@tag, view: 'characters') do
+            = link_to tag_path(@tag, view: 'characters'), rel: 'nofollow' do
               = image_tag "icons/group.png", class: 'vmid', alt: ''
               Characters
       - if @tag.is_a?(ContentWarning)
         %tr
           %td.centered{class: cycle('even', 'odd')}
-            = link_to tag_path(@tag, view: 'users') do
+            = link_to tag_path(@tag, view: 'users'), rel: 'nofollow' do
               = image_tag "icons/group.png", class: 'vmid', alt: ''
               Users
       - if @tag.is_a?(Setting) && @tag.child_settings.present?
         %tr
           %td.centered{class: cycle('even', 'odd')}
-            = link_to tag_path(@tag, view: 'settings') do
+            = link_to tag_path(@tag, view: 'settings'), rel: 'nofollow' do
               = image_tag "icons/world.png", class: 'vmid', alt: ''
               Settings
       - if @tag.editable_by?(current_user)

--- a/app/views/templates/show.haml
+++ b/app/views/templates/show.haml
@@ -25,11 +25,11 @@
               Edit Template
           = link_to @template, method: :delete, data: { confirm: 'Are you sure you want to delete this template?' } do
             .link-box.action-delete x Delete Template
-        = link_to character_menu_link(view: 'icons'), class: 'view-button-link' do
+        = link_to character_menu_link(view: 'icons'), rel: 'nofollow', class: 'view-button-link' do
           .view-button{class: (:selected unless page_view == 'list')}
             = image_tag "icons/grid.png", class: 'icon-view', alt: ''
             Icons
-        = link_to character_menu_link(view: 'list'), class: 'view-button-link' do
+        = link_to character_menu_link(view: 'list'), rel: 'nofollow', class: 'view-button-link' do
           .view-button{class: (:selected if page_view == 'list')}
             = image_tag "icons/list.png", class: 'list-view', alt: ''
             List


### PR DESCRIPTION
Should reduce the amount of crawler spam we get (esp on `icons/:id?view=:view`, which is heavily trafficked)