### PR TITLE
Fix internal SCSS deprecations

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
 @use 'sass:math';
-@import 'palette';
+@use 'palette' as *;
 
 // Variables
 // global font sizes

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use 'sass:math';
 @import 'palette';
 
@@ -147,9 +148,9 @@ $bg_color_content_border: transparent !default; // from river, is 0-width in def
 // mix colors X and Y with weight W (favoring Y, allowing values outside 0 and 1)
 @function mix-allow-heavy($color1, $color2, $value) {
   // @return (1 - $value) * $color1 + ($color2 * $value);
-  $red: (1 - $value) * red($color1) + (red($color2) * $value);
-  $green: (1 - $value) * green($color1) + (green($color2) * $value);
-  $blue: (1 - $value) * blue($color1) + (blue($color2) * $value);
+  $red: (1 - $value) * color.channel($color1, 'red', $space: rgb) + (color.channel($color2, 'red', $space: rgb) * $value);
+  $green: (1 - $value) * color.channel($color1, 'green', $space: rgb) + (color.channel($color2, 'green', $space: rgb) * $value);
+  $blue: (1 - $value) * color.channel($color1, 'blue', $space: rgb) + (color.channel($color2, 'blue', $space: rgb) * $value);
   @return rgb($red, $green, $blue);
 }
 

--- a/app/assets/stylesheets/characters.scss
+++ b/app/assets/stylesheets/characters.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 // default icon selector
 #character-icon-selector {

--- a/app/assets/stylesheets/galleries.scss
+++ b/app/assets/stylesheets/galleries.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 .gallery-box {
   cursor: pointer;

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 body, html { height: 100%; }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 /* Header Menus */
 #header {

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 /* - main page */
 body {
@@ -179,7 +179,7 @@ tr.gallery-tags .tag-item {
   color: $font_color_reply_content;
 }
 
-@import 'dark_themes_selectors';
+@use 'dark_themes_selectors';
 
 /* TODO: do this for starrydark */
 .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default, .ui-button, html .ui-button.ui-state-disabled:hover, html .ui-button.ui-state-disabled:active {

--- a/app/assets/stylesheets/layouts/_dark_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_selectors.scss
@@ -1,5 +1,7 @@
 @use 'variables' as *;
 
+@use 'dark_themes_selectors';
+
 /* - main page */
 body {
   background-color: $bg_color_page;
@@ -178,8 +180,6 @@ tr.gallery-tags .tag-item {
   background-color: $bg_color_reply_content;
   color: $font_color_reply_content;
 }
-
-@use 'dark_themes_selectors';
 
 /* TODO: do this for starrydark */
 .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default, .ui-button, html .ui-button.ui-state-disabled:hover, html .ui-button.ui-state-disabled:active {

--- a/app/assets/stylesheets/layouts/_dark_themes_selectors.scss
+++ b/app/assets/stylesheets/layouts/_dark_themes_selectors.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 /* Hovering help box on post editor */
 .ui-widget-header {

--- a/app/assets/stylesheets/layouts/_monochrome_selectors.scss
+++ b/app/assets/stylesheets/layouts/_monochrome_selectors.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 /* - header */
 #logo { background-color: $bg_color_header_top; }

--- a/app/assets/stylesheets/layouts/_river_selectors.scss
+++ b/app/assets/stylesheets/layouts/_river_selectors.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 /* - main page */
 body { background-color: $bg_color_page; }

--- a/app/assets/stylesheets/layouts/_starry_default_selectors.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_selectors.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'starry_default_variables' as *;
 
 /* - header */
 #header {

--- a/app/assets/stylesheets/layouts/_starry_default_variables.scss
+++ b/app/assets/stylesheets/layouts/_starry_default_variables.scss
@@ -1,86 +1,90 @@
-@import 'palette';
+@use 'palette' as *;
+@forward 'palette';
 
-// header
-$bg_color_header_middle: #05050F !default; // middle header strip with user items
-$bg_color_header_bottom: $colors_gunpowder !default; // bottom header strip with navigation
-$font_color_header_link_hover: $colors_silver !default;
+@use 'variables' with (
+  // header
+  $bg_color_header_middle: #05050F, // middle header strip with user items
+  $bg_color_header_bottom: $colors_gunpowder, // bottom header strip with navigation
+  $font_color_header_link_hover: $colors_silver,
 
-// main page
-$font_color_page: $colors_black !default;
+  // main page
+  $font_color_page: $colors_black,
 
-$font_color_search_box: $colors_bright !default;
+  $font_color_search_box: $colors_bright,
 
-// links
-$font_color_link: #666284 !default; // link
-$font_color_link_visited: $colors_gunpowder !default;
+  // links
+  $font_color_link: #666284, // link
+  $font_color_link_visited: $colors_gunpowder,
 
-// flashes
-// these are the notifications that appear when you submit a form or get a message
-$font_color_breadcrumbs_bold: $colors_concrete !default;
-$font_color_breadcrumbs_link_visited: $colors_santasgrey !default;
+  // flashes
+  // these are the notifications that appear when you submit a form or get a message
+  $font_color_breadcrumbs_bold: $colors_concrete,
+  $font_color_breadcrumbs_link_visited: $colors_santasgrey,
 
-// misc
-$font_color_descriptions_link: $colors_logan !default;
-$font_color_descriptions_link_visited: $colors_santasgrey !default;
-$bg_color_descriptions: $colors_gunpowder !default; // description subheadings on templates page ("single-description"), *not* posts
+  // misc
+  $font_color_descriptions_link: $colors_logan,
+  $font_color_descriptions_link_visited: $colors_santasgrey,
+  $bg_color_descriptions: $colors_gunpowder, // description subheadings on templates page ("single-description"), *not* posts
 
-// content headers
-$font_color_head_link: $colors_logan !default; // TODO: check this
-$font_color_head_link_visited: $colors_santasgrey !default;
+  // content headers
+  $font_color_head_link: $colors_logan, // TODO: check this
+  $font_color_head_link_visited: $colors_santasgrey,
 
-$font_color_sub: $colors_concrete !default;
+  $font_color_sub: $colors_concrete,
 
-$bg_color_subber: $colors_gunpowder !default; // tertiary content header
-$font_color_subber_bold: $colors_concrete !default;
-$font_color_subber_link_visited: $colors_santasgrey !default;
+  $bg_color_subber: $colors_gunpowder, // tertiary content header
+  $font_color_subber_bold: $colors_concrete,
+  $font_color_subber_link_visited: $colors_santasgrey,
 
-// content
-$bg_color_even: #E3E3E3 !default;
-$bg_color_odd: $colors_alto_darker !default;
-$opacity_blockquote: 0.2 !default;
+  // content
+  $bg_color_even: #E3E3E3,
+  $bg_color_odd: $colors_alto_darker,
+  $opacity_blockquote: 0.2,
 
-// posts
-$bg_color_navbutton: $colors_mulledwine !default;
+  // posts
+  $bg_color_navbutton: $colors_mulledwine,
 
-$font_color_post_description: $colors_concrete !default;
-$bg_color_post_description: $colors_gunpowder !default;
+  $font_color_post_description: $colors_concrete,
+  $bg_color_post_description: $colors_gunpowder,
 
-$border_color_post_menu: #808080 !default;
-$bg_color_post_menu: #BCBCBC !default;
-$bg_color_menu_link_hover: #D3D3D3 !default;
+  $border_color_post_menu: #808080,
+  $bg_color_post_menu: #BCBCBC,
+  $bg_color_menu_link_hover: #D3D3D3,
 
-$bg_color_selectionpopup: $colors_gunpowder !default; // selection popups like character/alias on posts#editor
-$font_color_selectionpopup: $colors_alto_brighter !default;
-$bg_color_icon_selector: $colors_gunpowder !default;
-$font_color_icon_selector: $colors_alto_brighter !default;
+  $bg_color_selectionpopup: $colors_gunpowder, // selection popups like character/alias on posts#editor
+  $font_color_selectionpopup: $colors_alto_brighter,
+  $bg_color_icon_selector: $colors_gunpowder,
+  $font_color_icon_selector: $colors_alto_brighter,
 
-$font_color_post_info: $colors_concrete !default;
-$font_weight_post_info: bold !default;
-$font_color_post_screenname: $colors_santasgrey !default;
+  $font_color_post_info: $colors_concrete,
+  $font_weight_post_info: bold,
+  $font_color_post_screenname: $colors_santasgrey,
 
-$font_color_paginate: $colors_concrete !default;
-$font_color_paginate_link: $colors_concrete !default;
-$font_color_paginate_link_visited: $colors_santasgrey !default;
-$font_color_paginate_link_disabled: #58546B;
-$bg_color_paginate_current_page: $colors_gunpowder !default;
+  $font_color_paginate: $colors_concrete,
+  $font_color_paginate_link: $colors_concrete,
+  $font_color_paginate_link_visited: $colors_santasgrey,
+  $font_color_paginate_link_disabled: #58546B,
+  $bg_color_paginate_current_page: $colors_gunpowder,
 
-// icons
-$bg_color_icon: $colors_alto_darker !default;
-$bg_color_icon_credit: $colors_alto_darker !default;
-$border_color_icon_editor: $colors_gunpowder !default;
-$bg_color_icon_editor: $colors_alto_darker !default;
+  // icons
+  $bg_color_icon: $colors_alto_darker,
+  $bg_color_icon_credit: $colors_alto_darker,
+  $border_color_icon_editor: $colors_gunpowder,
+  $bg_color_icon_editor: $colors_alto_darker,
 
-// tag items
-$font_color_tag_item: #444158 !default;
-$font_color_tag_item_gallery: #F7F7F7 !default;
+  // tag items
+  $font_color_tag_item: #444158,
+  $font_color_tag_item_gallery: #F7F7F7,
 
-// link-boxes
-$bg_color_linkbox_new: $colors_mulledwine !default;
-$bg_color_linkbox_edit: $colors_mulledwine !default;
-$bg_color_linkbox_favorite: $colors_mulledwine !default;
-$bg_color_linkbox_delete: $colors_mulledwine !default;
-$bg_color_linkbox_dismiss: $colors_mulledwine !default;
+  // link-boxes
+  $bg_color_linkbox_new: $colors_mulledwine,
+  $bg_color_linkbox_edit: $colors_mulledwine,
+  $bg_color_linkbox_favorite: $colors_mulledwine,
+  $bg_color_linkbox_delete: $colors_mulledwine,
+  $bg_color_linkbox_dismiss: $colors_mulledwine,
 
-// other buttons
-$bg_color_viewbutton: $colors_mulledwine !default;
-$bg_color_viewbutton_selected: #4D4B5B !default;
+  // other buttons
+  $bg_color_viewbutton: $colors_mulledwine,
+  $bg_color_viewbutton_selected: #4D4B5B,
+);
+@forward 'variables';

--- a/app/assets/stylesheets/layouts/dark.scss
+++ b/app/assets/stylesheets/layouts/dark.scss
@@ -1,118 +1,120 @@
-@import 'variables';
+@use 'palette' as *;
 
-// main page
-$bg_color_page: #212121; // overall page
-$font_color_page: $colors_silver_chalice;
-$font_color_content: $colors_silver_chalice; // body
+@use 'variables' with (
+  // main page
+  $bg_color_page: #212121, // overall page
+  $font_color_page: $colors_silver_chalice,
+  $font_color_content: $colors_silver_chalice, // body
 
-// header
-$bg_color_header_top: #3B4841; // top header strip for logo
-$bg_color_header_bottom: #56554F; // bottom header strip with navigation
-$font_color_header_link: #CCCCCC;  // header links
+  // header
+  $bg_color_header_top: #3B4841, // top header strip for logo
+  $bg_color_header_bottom: #56554F, // bottom header strip with navigation
+  $font_color_header_link: #CCCCCC,  // header links
 
-// links
-$font_color_link: #66997D; // link
-$font_color_link_visited: #66997D; // TODO: why the heck are these set the same
-$font_color_link_hover: #B3B3B3; // link (hovered)
+  // links
+  $font_color_link: #66997D, // link
+  $font_color_link_visited: #66997D, // TODO: why the heck are these set the same
+  $font_color_link_hover: #B3B3B3, // link (hovered)
 
-// flashes
-// these are the notifications that appear when you submit a form or get a message
-$bg_color_flash_success: #555E55; // success
-$font_color_flash_success: $colors_silver_again;
-$bg_color_flash_error: #532D38; // error
-$bg_color_flash_breadcrumbs: #464646; // breadcrumbs ("Continuities » Continuity » Section » Thread")
-$font_color_flash_breadcrumbs: $colors_alto;
-$font_color_flash_link: $colors_alto;
-$font_color_flash_hover: $colors_silver_again;
+  // flashes
+  // these are the notifications that appear when you submit a form or get a message
+  $bg_color_flash_success: #555E55, // success
+  $font_color_flash_success: $colors_silver_again,
+  $bg_color_flash_error: #532D38, // error
+  $bg_color_flash_breadcrumbs: #464646, // breadcrumbs ("Continuities » Continuity » Section » Thread")
+  $font_color_flash_breadcrumbs: $colors_alto,
+  $font_color_flash_link: $colors_alto,
+  $font_color_flash_hover: $colors_silver_again,
 
-$bg_color_spacer_alt: #333333;
-$bg_color_search_box: #333333;
-$font_color_search_box: $colors_silver_chalice;
+  $bg_color_spacer_alt: #333333,
+  $bg_color_search_box: #333333,
+  $font_color_search_box: $colors_silver_chalice,
 
-// misc
-$bg_color_descriptions: #565656; // description subheadings on templates page ("single-description"), *not* posts
+  // misc
+  $bg_color_descriptions: #565656, // description subheadings on templates page ("single-description"), *not* posts
 
-// content headers
-$bg_color_head: #424242; // primary content header
-$font_color_head: #C2C2C2;
+  // content headers
+  $bg_color_head: #424242, // primary content header
+  $font_color_head: #C2C2C2,
 
-$bg_color_sub: #383838; // secondary content header
-$font_color_sub: #C9C9C9;
+  $bg_color_sub: #383838, // secondary content header
+  $font_color_sub: #C9C9C9,
 
-$bg_color_subber: #464646; // tertiary content header
-$font_color_subber: $colors_alto;
+  $bg_color_subber: #464646, // tertiary content header
+  $font_color_subber: $colors_alto,
 
-$bg_color_ender: #464646;
-$font_color_ender: $colors_alto;
+  $bg_color_ender: #464646,
+  $font_color_ender: $colors_alto,
 
-// content
-$bg_color_even: #3E3E3E;
-$bg_color_odd: #474747;
+  // content
+  $bg_color_even: #3E3E3E,
+  $bg_color_odd: #474747,
 
-$bg_color_post_description: #5D5D5D;
-$font_color_post_description: $colors_silver_chalice;
-$bg_color_navheader: #5F5D57;
+  $bg_color_post_description: #5D5D5D,
+  $font_color_post_description: $colors_silver_chalice,
+  $bg_color_navheader: #5F5D57,
 
-$bg_color_selectionpopup: #565656; // selection popups like character/alias on posts#editor
-$bg_color_expander: #6F7769; // expander on posts
+  $bg_color_selectionpopup: #565656, // selection popups like character/alias on posts#editor
+  $bg_color_expander: #6F7769, // expander on posts
 
-$bg_color_post_icon: $colors_cabbage_pont;
-$bg_color_icon_selector: $colors_cabbage_pont;
-$font_color_icon_selector: #111111;
+  $bg_color_post_icon: $colors_cabbage_pont,
+  $bg_color_icon_selector: $colors_cabbage_pont,
+  $font_color_icon_selector: #111111,
 
-$bg_color_post_character: #595959;
-$bg_color_post_screenname: #515151;
-$bg_color_post_author: #4D4C4C;
-$font_color_post_info: $colors_silver_chalice;
-$font_color_post_screenname: $colors_silver_chalice;
+  $bg_color_post_character: #595959,
+  $bg_color_post_screenname: #515151,
+  $bg_color_post_author: #4D4C4C,
+  $font_color_post_info: $colors_silver_chalice,
+  $font_color_post_screenname: $colors_silver_chalice,
 
-$font_color_paginate: #C9C9C9;
+  $font_color_paginate: #C9C9C9,
 
-$font_color_post_menu: $colors_silver_chalice;
+  $font_color_post_menu: $colors_silver_chalice,
 
-// icons
-$bg_color_icon: $colors_cabbage_pont;
-$bg_color_icon_credit: $colors_cabbage_pont;
-$border_color_icon_editor: #464646;
-$bg_color_icon_editor: $colors_cabbage_pont;
+  // icons
+  $bg_color_icon: $colors_cabbage_pont,
+  $bg_color_icon_credit: $colors_cabbage_pont,
+  $border_color_icon_editor: #464646,
+  $bg_color_icon_editor: $colors_cabbage_pont,
 
-// tag items
-$bg_color_tag_item: #85837C;
-$font_color_tag_item: $colors_alto;
-$font_color_tag_item_gallery: $colors_alto;
+  // tag items
+  $bg_color_tag_item: #85837C,
+  $font_color_tag_item: $colors_alto,
+  $font_color_tag_item_gallery: $colors_alto,
 
-// link-boxes
-$font_color_linkbox: $colors_alto;
+  // link-boxes
+  $font_color_linkbox: $colors_alto,
 
-// other buttons
-$bg_color_viewbutton: #85837C;
-$bg_color_viewbutton_selected: #6A6A6A;
-$font_color_viewbutton: $colors_alto;
+  // other buttons
+  $bg_color_viewbutton: #85837C,
+  $bg_color_viewbutton_selected: #6A6A6A,
+  $font_color_viewbutton: $colors_alto,
 
-$bg_color_reply_content: #717171;
-$font_color_reply_content: #CCCCCC;
+  $bg_color_reply_content: #717171,
+  $font_color_reply_content: #CCCCCC,
 
-// Hovering help box on post editor
-$bg_color_popup_header: #2B2B2B;
-$font_color_popup_header: #C2C2C2;
-$border_color_popup_header: #262626;
-$bg_color_popup_content: #333333;
-$font_color_popup_content: $colors_silver_chalice;
-$border_color_popup: #444444;
-$bg_color_popup_button: #383838;
-$border_color_popup_button: #484848;
-$font_color_popup_link: #66997D;
+  // Hovering help box on post editor
+  $bg_color_popup_header: #2B2B2B,
+  $font_color_popup_header: #C2C2C2,
+  $border_color_popup_header: #262626,
+  $bg_color_popup_content: #333333,
+  $font_color_popup_content: $colors_silver_chalice,
+  $border_color_popup: #444444,
+  $bg_color_popup_button: #383838,
+  $border_color_popup_button: #484848,
+  $font_color_popup_link: #66997D,
 
-// Darken input boxes
-$font_color_input: $colors_silver_again; // TODO: standardize font color
-$bg_color_input: #4D4D4D; // for generic input boxes all over the place
-$bg_color_input_disabled: #393939;
-$border_color_input: #666666;
-$font_color_input_placeholder: #888888;
-$bg_color_mce_panel: #404040; // MCE header & footer background
-$bg_color_select2_highlight: #616161;
-$bg_color_select2_selected: #454545;
-$bg_color_select2_search: $bg_color_select2_highlight;
-$opacity_mce_label: 1;
+  // Darken input boxes
+  $font_color_input: $colors_silver_again, // TODO: standardize font color
+  $bg_color_input: #4D4D4D, // for generic input boxes all over the place
+  $bg_color_input_disabled: #393939,
+  $border_color_input: #666666,
+  $font_color_input_placeholder: #888888,
+  $bg_color_mce_panel: #404040, // MCE header & footer background
+  $bg_color_select2_highlight: #616161,
+  $bg_color_select2_selected: #454545,
+  $bg_color_select2_search: #616161,
+  $opacity_mce_label: 1,
+);
 
-@import 'dark_selectors'
+@use 'dark_selectors';

--- a/app/assets/stylesheets/layouts/monochrome.scss
+++ b/app/assets/stylesheets/layouts/monochrome.scss
@@ -1,56 +1,58 @@
-@import 'variables';
+@use 'palette' as *;
 
-// header
-$bg_color_header_top: #757575; // top header strip for logo
-$bg_color_header_middle: #4A4A4A; // middle header strip with user items
+@use 'variables' with (
+  // header
+  $bg_color_header_top: #757575, // top header strip for logo
+  $bg_color_header_middle: #4A4A4A, // middle header strip with user items
 
-// main page
-$bg_color_page: #E0E0E0; // overall page
+  // main page
+  $bg_color_page: #E0E0E0, // overall page
 
-// links
-$font_color_link: #6F6F6F; // link
-$font_color_link_visited: #484848;
+  // links
+  $font_color_link: #6F6F6F, // link
+  $font_color_link_visited: #484848,
 
-// flashes
-// these are the notifications that appear when you submit a form or get a message
-$bg_color_flash_success: $colors_gallery; // success
-$bg_color_flash_breadcrumbs: #ADADAD; // breadcrumbs ("Continuities » Continuity » Section » Thread")
+  // flashes
+  // these are the notifications that appear when you submit a form or get a message
+  $bg_color_flash_success: $colors_gallery, // success
+  $bg_color_flash_breadcrumbs: #ADADAD, // breadcrumbs ("Continuities » Continuity » Section » Thread")
 
-// content headers
-$bg_color_sub: $colors_silver_darker; // secondary content header
-$bg_color_subber: #ADADAD; // tertiary content header
-$bg_color_ender: #ADADAD; // tertiary content header
+  // content headers
+  $bg_color_sub: $colors_silver_darker, // secondary content header
+  $bg_color_subber: #ADADAD, // tertiary content header
+  $bg_color_ender: #ADADAD, // tertiary content header
 
-$bg_color_navheader: $colors_silver_darker;
+  $bg_color_navheader: $colors_silver_darker,
 
-$bg_color_expander: #A0A0A0; // expander on posts
+  $bg_color_expander: #A0A0A0, // expander on posts
 
-$bg_color_post_icon: $colors_silver_darker;
-$bg_color_icon_selector: $colors_silver_darker;
+  $bg_color_post_icon: $colors_silver_darker,
+  $bg_color_icon_selector: $colors_silver_darker,
 
-$bg_color_post_character: #929292;
-$bg_color_post_screenname: #A5A5A5;
-$bg_color_post_author: $colors_silver_again;
+  $bg_color_post_character: #929292,
+  $bg_color_post_screenname: #A5A5A5,
+  $bg_color_post_author: $colors_silver_again,
 
-$font_color_paginate_link_visited: #3A3A3A;
-$bg_color_paginate_current_page: #616161;
+  $font_color_paginate_link_visited: #3A3A3A,
+  $bg_color_paginate_current_page: #616161,
 
-// icons
-$bg_color_icon: $colors_silver_darker;
-$bg_color_icon_credit: $colors_silver_darker;
-$border_color_icon_editor: #ADADAD;
-$bg_color_icon_editor: $colors_silver_darker;
+  // icons
+  $bg_color_icon: $colors_silver_darker,
+  $bg_color_icon_credit: $colors_silver_darker,
+  $border_color_icon_editor: #ADADAD,
+  $bg_color_icon_editor: $colors_silver_darker,
 
-$font_color_tag_item: #575757;
-$font_color_tag_item_gallery: #575757;
+  $font_color_tag_item: #575757,
+  $font_color_tag_item_gallery: #575757,
 
-// link-boxes
-$bg_color_linkbox_new: #5A5A5A;
-$bg_color_linkbox_edit: $colors_comet;
-$bg_color_linkbox_favorite: $colors_comet;
-$bg_color_linkbox_delete: $colors_rock;
-$bg_color_linkbox_dismiss: $colors_rock;
+  // link-boxes
+  $bg_color_linkbox_new: #5A5A5A,
+  $bg_color_linkbox_edit: $colors_comet,
+  $bg_color_linkbox_favorite: $colors_comet,
+  $bg_color_linkbox_delete: $colors_rock,
+  $bg_color_linkbox_dismiss: $colors_rock,
 
-$bg_color_badge: #E5D8AF;
+  $bg_color_badge: #E5D8AF,
+);
 
-@import 'monochrome_selectors'
+@use 'monochrome_selectors';

--- a/app/assets/stylesheets/layouts/river.scss
+++ b/app/assets/stylesheets/layouts/river.scss
@@ -1,64 +1,66 @@
-@import 'variables';
+@use 'palette' as *;
 
-// main page
-$bg_color_page: #E0E0E0; // overall page
+@use 'variables' with (
+  // main page
+  $bg_color_page: #E0E0E0, // overall page
 
-// header
-$bg_color_header_top: #434D73; // top header strip for logo
-$bg_color_header_middle: #212135; // middle header strip with user items
-$bg_color_header_bottom: #ADB5B9; // bottom header strip with navigation
+  // header
+  $bg_color_header_top: #434D73, // top header strip for logo
+  $bg_color_header_middle: #212135, // middle header strip with user items
+  $bg_color_header_bottom: #ADB5B9, // bottom header strip with navigation
 
-// links
-$font_color_link: #3F5970; // link
-$font_color_link_visited: #284150;
+  // links
+  $font_color_link: #3F5970, // link
+  $font_color_link_visited: #284150,
 
-// flashes
-$bg_color_flash_success: $colors_gallery; // success
-$bg_color_flash_breadcrumbs: #A3A8A9; // breadcrumbs ("Continuities » Continuity » Section » Thread")
+  // flashes
+  $bg_color_flash_success: $colors_gallery, // success
+  $bg_color_flash_breadcrumbs: #A3A8A9, // breadcrumbs ("Continuities » Continuity » Section » Thread")
 
-// content headers
-$bg_color_sub: $colors_silver_darker; // secondary content header
-$bg_color_subber: #B9B6AD; // tertiary content header
-$bg_color_ender: #A3A8A9; // form table footer with submit
+  // content headers
+  $bg_color_sub: $colors_silver_darker, // secondary content header
+  $bg_color_subber: #B9B6AD, // tertiary content header
+  $bg_color_ender: #A3A8A9, // form table footer with submit
 
-// content
-$bg_color_even: #F3F3F3;
-$bg_color_odd: #E8E8E8;
-$bg_color_content_border: #AAAAAA;
+  // content
+  $bg_color_even: #F3F3F3,
+  $bg_color_odd: #E8E8E8,
+  $bg_color_content_border: #AAAAAA,
 
-$font_color_reply_footer: #717171;
+  $font_color_reply_footer: #717171,
 
-$bg_color_navheader: $colors_silver_darker;
+  $bg_color_navheader: $colors_silver_darker,
 
-$font_color_paginate_link_visited: #3A3A3A;
-$bg_color_paginate_current_page: #718EB9;
+  $font_color_paginate_link_visited: #3A3A3A,
+  $bg_color_paginate_current_page: #718EB9,
 
-$bg_color_expander: #A4B0BD; // expander on posts
+  $bg_color_expander: #A4B0BD, // expander on posts
 
-$bg_color_post_icon: $colors_hit_gray;
-$bg_color_icon_selector: $colors_hit_gray;
+  $bg_color_post_icon: $colors_hit_gray,
+  $bg_color_icon_selector: $colors_hit_gray,
 
-$bg_color_post_character: #929292;
-$bg_color_post_screenname: #A5A5A5;
-$bg_color_post_author: $colors_silver_again;
-$font_color_post_info: #B3D3FF;
+  $bg_color_post_character: #929292,
+  $bg_color_post_screenname: #A5A5A5,
+  $bg_color_post_author: $colors_silver_again,
+  $font_color_post_info: #B3D3FF,
 
-// icons
-$bg_color_icon: $colors_hit_gray;
-$bg_color_icon_credit: $colors_hit_gray;
-$border_color_icon_editor: #B9B6AD;
-$bg_color_icon_editor: $colors_hit_gray;
+  // icons
+  $bg_color_icon: $colors_hit_gray,
+  $bg_color_icon_credit: $colors_hit_gray,
+  $border_color_icon_editor: #B9B6AD,
+  $bg_color_icon_editor: $colors_hit_gray,
 
-// tag items
-$font_color_tag_item: #3E526F;
-$font_color_tag_item_gallery: #3E526F;
-$bg_color_tag_item: #D0CEC8;
+  // tag items
+  $font_color_tag_item: #3E526F,
+  $font_color_tag_item_gallery: #3E526F,
+  $bg_color_tag_item: #D0CEC8,
 
-// link-boxes
-$bg_color_linkbox_new: #3F5370;
-$bg_color_linkbox_edit: $colors_comet;
-$bg_color_linkbox_favorite: $colors_comet;
-$bg_color_linkbox_delete: $colors_rock;
-$bg_color_linkbox_dismiss: $colors_rock;
+  // link-boxes
+  $bg_color_linkbox_new: #3F5370,
+  $bg_color_linkbox_edit: $colors_comet,
+  $bg_color_linkbox_favorite: $colors_comet,
+  $bg_color_linkbox_delete: $colors_rock,
+  $bg_color_linkbox_dismiss: $colors_rock,
+);
 
-@import 'river_selectors'
+@use 'river_selectors';

--- a/app/assets/stylesheets/layouts/starry.scss
+++ b/app/assets/stylesheets/layouts/starry.scss
@@ -1,4 +1,4 @@
-@import 'starry_default_variables';
+@use 'starry_default_variables' as *;
 
 // main page
 $bg_color_page: #6C697C; // overall page
@@ -41,7 +41,7 @@ $bg_color_tag_item: #2C2C5D;
 // link-boxes
 $bg_color_linkbox_subber: #66608B;
 
-@import 'starry_default_selectors';
+@use 'starry_default_selectors';
 
 // posts
 #post-menu-box { color: $font_color_post_menu; }

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -60,6 +60,8 @@ $bg_color_linkbox_subber: #5C5778;
 
 @use 'starry_default_selectors';
 
+@use 'dark_themes_selectors';
+
 .flash.success, .flash.error { color: $font_color_flash; }
 
 body, .even, .odd, .post-post, .post-reply, .profile, #post-editor { color: $font_color_page; }
@@ -101,5 +103,3 @@ $bg_color_select2_highlight: #5B586B;
 $bg_color_select2_selected: #3F3D4C;
 $bg_color_select2_search: $bg_color_select2_highlight;
 $opacity_mce_label: 0.8;
-
-@use 'dark_themes_selectors'

--- a/app/assets/stylesheets/layouts/starrydark.scss
+++ b/app/assets/stylesheets/layouts/starrydark.scss
@@ -1,4 +1,4 @@
-@import 'starry_default_variables';
+@use 'starry_default_variables' as *;
 
 // main page
 $bg_color_page: #211E2F; // overall page
@@ -58,7 +58,7 @@ $bg_color_tag_item_odd: #1A1A22;
 // link-boxes
 $bg_color_linkbox_subber: #5C5778;
 
-@import 'starry_default_selectors';
+@use 'starry_default_selectors';
 
 .flash.success, .flash.error { color: $font_color_flash; }
 
@@ -102,4 +102,4 @@ $bg_color_select2_selected: #3F3D4C;
 $bg_color_select2_search: $bg_color_select2_highlight;
 $opacity_mce_label: 0.8;
 
-@import 'dark_themes_selectors'
+@use 'dark_themes_selectors'

--- a/app/assets/stylesheets/layouts/starrylight.scss
+++ b/app/assets/stylesheets/layouts/starrylight.scss
@@ -1,4 +1,4 @@
-@import 'starry_default_variables';
+@use 'starry_default_variables' as *;
 
 // main page
 $bg_color_page: #B0AFB7; // overall page
@@ -75,7 +75,7 @@ $bg_color_linkbox_subber: $colors_wildblueyonder;
 $bg_color_viewbutton: $colors_scampi;
 $bg_color_viewbutton_selected: $colors_wildblueyonder;
 
-@import 'starry_default_selectors';
+@use 'starry_default_selectors';
 
 // posts
 .post-screenname, .post-screenname a, .post-screenname a:visited { font-style: italic; }

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 #message-row {
   width: 75%;

--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 /* Box displaying current icon */
 #icon-overlay {

--- a/app/assets/stylesheets/tinymce.scss
+++ b/app/assets/stylesheets/tinymce.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 body {
   background-color: $bg_color_input;


### PR DESCRIPTION
Can't fix the warnings from bootstrap - seems they haven't updated yet (https://github.com/twbs/bootstrap/blob/main/scss/bootstrap.scss is using `@import` as of the date of this PR) - but we can update our internal SCSS files!