### PR TITLE
Reduce error emails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,8 @@ class ApplicationController < ActionController::Base
     posts = posts_relation_filter(relation, no_tests: no_tests, show_blocked: show_blocked)
     posts_count = posts.except(:select, :order, :group).count('DISTINCT posts.id')
     posts = posts_list_relation(posts, select: select, max: max)
-    posts = posts.paginate(page: page, total_entries: posts_count) if with_pagination
+    safe_page = page.to_i == 0 ? 1 : page.to_i # protects against 'last' and 'unread' on controllers that don't support it
+    posts = posts.paginate(page: safe_page, total_entries: posts_count) if with_pagination
     calculate_view_status(posts, with_unread: with_unread) if logged_in?
     posts
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,11 +43,11 @@ class ApplicationController < ActionController::Base
   end
 
   VALID_PAGES = ['last', 'unread']
-  def page
+  def page(allow_special: false)
     return @page if @page
     return (@page = 1) unless params[:page]
     @page = params[:page]
-    return @page if VALID_PAGES.include?(@page)
+    return @page if allow_special && VALID_PAGES.include?(@page)
     @page = @page.to_i
     return @page if @page > 0
     flash.now[:error] = "Page not recognized, defaulting to page 1."
@@ -92,8 +92,7 @@ class ApplicationController < ActionController::Base
     posts = posts_relation_filter(relation, no_tests: no_tests, show_blocked: show_blocked)
     posts_count = posts.except(:select, :order, :group).count('DISTINCT posts.id')
     posts = posts_list_relation(posts, select: select, max: max)
-    safe_page = page.to_i == 0 ? 1 : page.to_i # protects against 'last' and 'unread' on controllers that don't support it
-    posts = posts.paginate(page: safe_page, total_entries: posts_count) if with_pagination
+    posts = posts.paginate(page: page, total_entries: posts_count) if with_pagination
     calculate_view_status(posts, with_unread: with_unread) if logged_in?
     posts
   end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -56,7 +56,7 @@ class BoardsController < ApplicationController
   def show
     @page_title = @board.name
     @board_sections = @board.board_sections.ordered
-    @board_sections = @board_sections.paginate(per_page: 25, page: params[:page])
+    @board_sections = @board_sections.paginate(per_page: 25, page: page)
     board_posts = @board.posts.where(section_id: nil)
     if @board.ordered?
       board_posts = board_posts.ordered_in_section

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -66,7 +66,7 @@ class GalleriesController < UploadingController
       @meta_og = og_data
     end
     @icons = @gallery ? @gallery.icons : @user.galleryless_icons
-    @icons = @icons.paginate(per_page: 100, page: params[:page])
+    @icons = @icons.paginate(per_page: 100, page: page)
     @times_used, @posts_used = Icon.times_used(@icons, current_user) if page_view == 'list'
     response.headers['X-Robots-Tag'] = 'noindex' if params[:view]
     render :show, locals: { icons: @icons }

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -19,7 +19,7 @@ class GalleriesController < UploadingController
       @user.username + "'s Galleries"
     end
     @galleries = @user.galleries.ordered_by_name
-    @galleries = @galleries.paginate(per_page: 100, page: params[:page])
+    @galleries = @galleries.paginate(per_page: 100, page: page)
     use_javascript('galleries/expander')
     gon.user_id = @user.id
   end

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -37,7 +37,7 @@ class WritableController < ApplicationController
 
   def show_post(cur_page=nil)
     per = per_page
-    cur_page ||= page
+    cur_page ||= page(allow_special: true)
     @replies = @post.replies
     @paginate_params = { controller: 'posts', action: 'show', id: @post.id }
 

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -82,7 +82,7 @@
     - elsif @user.characters.exists?
       - templates = @user.templates.ordered
       - templates = templates.where(retired: false) unless show_retired
-      - templates = templates.paginate(per_page: 25, page: params[:page]) if templates.count > 50
+      - templates = templates.paginate(per_page: 25, page: page) if templates.count > 50
       = render partial: partial_type, collection: templates, as: :name
       - templateless = @user.characters.non_npcs.where(template_id: nil)
       - if templateless.exists? && (templates.methods.exclude?(:total_pages) || templates.total_pages == params[:page].to_i)

--- a/app/views/characters/index.haml
+++ b/app/views/characters/index.haml
@@ -82,7 +82,7 @@
     - elsif @user.characters.exists?
       - templates = @user.templates.ordered
       - templates = templates.where(retired: false) unless show_retired
-      - templates = templates.paginate(per_page: 25, page: page) if templates.count > 50
+      - templates = templates.paginate(per_page: 25, page: params[:page]) if templates.count > 50
       = render partial: partial_type, collection: templates, as: :name
       - templateless = @user.characters.non_npcs.where(template_id: nil)
       - if templateless.exists? && (templates.methods.exclude?(:total_pages) || templates.total_pages == params[:page].to_i)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,7 +100,11 @@ Rails.application.configure do
 
   # use ExceptionNotification to email Marri stack traces
   Rails.application.config.middleware.use ExceptionNotification::Rack,
-    ignore_exceptions: ['Rack::Timeout::RequestTimeoutException','ActiveRecord::QueryCanceled','ActionDispatch::Http::MimeNegotiation::InvalidType'] + ExceptionNotifier.ignored_exceptions,
+    ignore_exceptions: [
+      'Rack::Timeout::RequestTimeoutException',
+      'ActiveRecord::QueryCanceled',
+      'ActionDispatch::Http::MimeNegotiation::InvalidType'
+      ] + ExceptionNotifier.ignored_exceptions,
     email: {
       email_prefix: "[Glowfic Constellation Error] ",
       sender_address: %{"Glowfic Constellation" <glowfic.constellation@gmail.com>},

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,8 +103,8 @@ Rails.application.configure do
     ignore_exceptions: [
       'Rack::Timeout::RequestTimeoutException',
       'ActiveRecord::QueryCanceled',
-      'ActionDispatch::Http::MimeNegotiation::InvalidType'
-      ] + ExceptionNotifier.ignored_exceptions,
+      'ActionDispatch::Http::MimeNegotiation::InvalidType',
+    ] + ExceptionNotifier.ignored_exceptions,
     email: {
       email_prefix: "[Glowfic Constellation Error] ",
       sender_address: %{"Glowfic Constellation" <glowfic.constellation@gmail.com>},

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
 
   # use ExceptionNotification to email Marri stack traces
   Rails.application.config.middleware.use ExceptionNotification::Rack,
+    ignore_exceptions: ['Rack::Timeout::RequestTimeoutException','ActiveRecord::QueryCanceled','ActionDispatch::Http::MimeNegotiation::InvalidType'] + ExceptionNotifier.ignored_exceptions,
     email: {
       email_prefix: "[Glowfic Constellation Error] ",
       sender_address: %{"Glowfic Constellation" <glowfic.constellation@gmail.com>},

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -266,6 +266,13 @@ RSpec.describe BoardsController do
       expect(assigns(:board_sections).total_pages).to eq(2)
     end
 
+    it "does not choke on bad pages" do
+      create_list(:board_section, 26, board: board)
+      get :show, params: { id: board.id, page: "nvOpzp; AND 1=1" }
+      expect(assigns(:board_sections).size).to eq(25)
+      expect(assigns(:board_sections).total_pages).to eq(2)
+    end
+
     it "orders the posts by tagged_at in unordered boards" do
       Array.new(3) { create(:post, board: board, tagged_at: Time.zone.now + rand(5..30).hours) }
       get :show, params: { id: board.id }

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe GalleriesController do
         expect(assigns(:page_title)).to eq("#{user.username}'s Galleries")
       end
 
+      it "displays error on invalid pages" do
+        user = create(:user)
+        get :index, params: { user_id: user.id, page: "2'" }
+        expect(response).to have_http_status(200)
+        expect(flash[:error]).to eq("Page not recognized, defaulting to page 1.")
+      end
+
       it "displays error if user id invalid and logged out" do
         get :index, params: { user_id: -1 }
         expect(flash[:error]).to eq('User could not be found.')

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe GalleriesController do
 
       it "displays error on invalid pages" do
         user = create(:user)
-        get :index, params: { user_id: user.id, page: "2'" }
+        get :index, params: { user_id: user.id, page: "nvOpzp; AND 1=1" }
         expect(response).to have_http_status(200)
         expect(assigns(:page)).to eq(1)
       end
@@ -183,7 +183,7 @@ RSpec.describe GalleriesController do
 
         it "displays error on invalid pages" do
           user = create(:user)
-          get :show, params: { id: '0', user_id: user.id, page: "2'" }
+          get :show, params: { id: '0', user_id: user.id, page: "'" }
           expect(response).to render_template('show')
           expect(response).to have_http_status(200)
           expect(assigns(:page)).to eq(1)

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe GalleriesController do
         user = create(:user)
         get :index, params: { user_id: user.id, page: "2'" }
         expect(response).to have_http_status(200)
-        expect(flash[:error]).to eq("Page not recognized, defaulting to page 1.")
+        expect(flash.now[:error]).to eq("Page not recognized, defaulting to page 1.")
       end
 
       it "displays error if user id invalid and logged out" do
@@ -186,7 +186,7 @@ RSpec.describe GalleriesController do
           get :show, params: { id: '0', user_id: user.id, page: "2'" }
           expect(response).to render_template('show')
           expect(response).to have_http_status(200)
-          expect(flash[:error]).to eq("Page not recognized, defaulting to page 1.")
+          expect(flash.now[:error]).to eq("Page not recognized, defaulting to page 1.")
         end
 
         it "requires specified user to be full user" do

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -174,6 +174,14 @@ RSpec.describe GalleriesController do
           expect(flash[:error]).to eq('User could not be found.')
         end
 
+        it "displays error on invalid pages" do
+          user = create(:user)
+          get :show, params: { id: '0', user_id: user.id, page: "2'" }
+          expect(response).to render_template('show')
+          expect(response).to have_http_status(200)
+          expect(flash[:error]).to eq("Page not recognized, defaulting to page 1.")
+        end
+
         it "requires specified user to be full user" do
           user = create(:reader_user)
           get :index, params: { user_id: user.id }

--- a/spec/controllers/galleries_controller_spec.rb
+++ b/spec/controllers/galleries_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe GalleriesController do
         user = create(:user)
         get :index, params: { user_id: user.id, page: "2'" }
         expect(response).to have_http_status(200)
-        expect(flash.now[:error]).to eq("Page not recognized, defaulting to page 1.")
+        expect(assigns(:page)).to eq(1)
       end
 
       it "displays error if user id invalid and logged out" do
@@ -186,7 +186,7 @@ RSpec.describe GalleriesController do
           get :show, params: { id: '0', user_id: user.id, page: "2'" }
           expect(response).to render_template('show')
           expect(response).to have_http_status(200)
-          expect(flash.now[:error]).to eq("Page not recognized, defaulting to page 1.")
+          expect(assigns(:page)).to eq(1)
         end
 
         it "requires specified user to be full user" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe ReportsController do
       expect(response).to have_http_status(200)
     end
 
+    it "handles bad pages" do
+      get :show, params: { id: 'daily', page: 'unread' }
+      expect(response).to have_http_status(200)
+    end
+
     it "sets variables with logged in daily" do
       user = create(:user)
       post = create(:post)

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Character" do
 
   describe "index" do
     it "handles bad pages" do
-      user = create(:user)
+      user = create(:user, password: known_test_password)
       create(:character, user: user)
       create_list(:template, 51, user: user)
       login(user)

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -143,4 +143,21 @@ RSpec.describe "Character" do
       end
     end
   end
+
+  describe "index" do
+    it "handles bad pages" do
+      user = create(:user)
+      create(:character, user: user)
+      create_list(:template, 51, user: user)
+      login(user)
+
+      get "/characters?page=nvOpzp; AND 1=1"
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:index)
+        expect(response.body).to include("#{user.username}'s Characters")
+      end
+    end
+  end
 end

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Character" do
     it "handles bad pages" do
       user = create(:user, password: known_test_password)
       create(:character, user: user)
-      create_list(:template, 51, user: user)
+      create_list(:template, 51, user: user) # rubocop:disable FactoryBot/ExcessiveCreateList
       login(user)
 
       get "/characters?page=nvOpzp; AND 1=1"

--- a/spec/requests/characters_spec.rb
+++ b/spec/requests/characters_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Character" do
       aggregate_failures do
         expect(response).to have_http_status(200)
         expect(response).to render_template(:index)
-        expect(response.body).to include("#{user.username}'s Characters")
+        expect(response.body).to include("Your Characters")
       end
     end
   end

--- a/spec/system/characters/index_spec.rb
+++ b/spec/system/characters/index_spec.rb
@@ -187,6 +187,11 @@ RSpec.describe "Listing characters" do
 
     include_examples "characters#index", false
 
+    scenario "Handles bad pages" do
+      visit user_characters_path(user_id: user.id, view: 'list', character_split: 'template', page: "nvOpzp; AND 1=1")
+      expect(page).to have_text("Sample user's Characters")
+    end
+
     scenario "Viewing NPCs" do
       create(:character, user: user, npc: true, name: "MyNPC")
 


### PR DESCRIPTION
Should be released concurrently with adding a Heroku alert for slow response time, to replace the functionality of the `Rack::Timeout::RequestTimeoutException` emails.

The `ActiveRecord::QueryCanceled` emails are also timeouts, and can be mostly replaced with the Heroku alert as well, but do represent an actual problem we should address with code/infra beyond just with General Speed Things Up specifically for search pages. Do not personally think it's worth keeping error emails about it, but open to input, since we don't have fine tuned alerting for things like "slow searches specifically" atm.

`ActionDispatch::Http::MimeNegotiation::InvalidType` has historically only been thrown by nonsense and I do not expect any of them represent real legitimate user-facing errors, so they can go away too.

We also get various emails of the type
```
  invalid value for Integer(): "unread"
  app/controllers/application_controller.rb:95:in `posts_from_relation'
```
coming from controllers that do not support "last" or "unread" pages, but which were passed it as a page anyway. This should protect us, but plausibly we should be designing this better, so counter-designs welcome.