### PR TITLE
put the "previous post" button back on the left

### DIFF
--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -179,8 +179,8 @@
       = link_to post_path(@next_post), class: 'view-button-link' do
         .view-button Next Post &raquo;
     - if @prev_post
-      = link_to post_path(@prev_post), class: 'view-button-link' do
-        .view-button.float-none &laquo; Previous Post
+      = link_to post_path(@prev_post), class: 'view-button-link float-left' do
+        .view-button &laquo; Previous Post
 - if page.to_i == 1
   = render 'replies/single', reply: @post, split_ui: split_ui
 - else
@@ -199,8 +199,8 @@
         = link_to post_path(@next_post), class: 'view-button-link' do
           .view-button Next Post &raquo;
       - if @prev_post
-        = link_to post_path(@prev_post), class: 'view-button-link' do
-          .view-button.float-none &laquo; Previous Post
+        = link_to post_path(@prev_post), class: 'view-button-link float-left' do
+          .view-button &laquo; Previous Post
 - if @post.on_hiatus? && (@replies.empty? || (@replies.last.id == @post.last_reply_id))
   .post-ender This Thread Is On Hiatus
 - if @post.abandoned? && (@replies.empty? || (@replies.last.id == @post.last_reply_id))


### PR DESCRIPTION
Put the "previous post" button on the left of the page, instead of floating to the right just before the "next post" button.