### PR TITLE
Fix various small issues with the multi-reply editor

### DIFF
--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -168,7 +168,7 @@ function setupWritableEditor() {
   $(".char-access-icon").click(function() {
     const id = $(this).data('character-id');
     $("#reply_character_id").val(id);
-    getAndSetCharacterData({ id: id }, { updateCharDropdowns: true,  aliasOverride: findMultiReplyAlias(id)});
+    getAndSetCharacterData({ id: id }, { updateCharDropdowns: true, aliasOverride: findMultiReplyAlias(id)});
   });
 
   $("#character_alias").change(function() {

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -280,6 +280,7 @@ function setFormData(characterId, resp, options) {
   let restoreAlias = false;
   let hideCharacterSelect = true;
   let updateCharDropdowns = false;
+  let charAliasOverride = null;
 
   if (typeof options !== 'undefined') {
     restoreIcon = options.restore_icon;

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -90,7 +90,7 @@ function findMultiReplyAlias(characterId) {
   // I'm editing a multi-reply, so the relevant character might have aliases here that are not set in the thread
   let aliasOverride = null;
   const jsonArray = JSON.parse(multiRepliesJsonElement.value);
-  const latestElement = jsonArray.slice().reverse().find(item => item.character_id === String(characterId));
+  const latestElement = jsonArray.reverse().find(item => item.character_id === String(characterId));
   const aliasOverrideStr = latestElement ? latestElement.character_alias_id : null;
   if (aliasOverrideStr && aliasOverrideStr !== "") {
     aliasOverride = Number(aliasOverrideStr);

--- a/app/assets/javascripts/posts/editor.js
+++ b/app/assets/javascripts/posts/editor.js
@@ -91,7 +91,7 @@ function findMultiReplyAlias(characterId) {
   let aliasOverride = null;
   const jsonArray = JSON.parse(multiRepliesJsonElement.value);
   const latestElement = jsonArray.slice().reverse().find(item => item.character_id === String(characterId));
-  aliasOverrideStr = latestElement ? latestElement.character_alias_id : null;
+  const aliasOverrideStr = latestElement ? latestElement.character_alias_id : null;
   if (aliasOverrideStr && aliasOverrideStr !== "") {
     aliasOverride = Number(aliasOverrideStr);
   }

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -261,11 +261,7 @@ class RepliesController < WritableController
     @post = reply.post
     empty_reply_hash = permitted_params.permit(:character_id, :character_alias_id)
     @reply = @post.build_new_reply_for(current_user, empty_reply_hash)
-    if @reply.character_id.nil?
-      @reply.icon_id = current_user.avatar_id
-    else
-      @reply.icon_id = @reply.character.default_icon.try(:id)
-    end
+    @reply.assign_default_icon(current_user)
     @reply.editor_mode = reply.editor_mode
     @adding_to_multi_reply = true
     @audits = {}

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -335,6 +335,7 @@ class RepliesController < WritableController
 
   def editing_multi_reply?
     # If the list of params is present and the first item on the list has the ID stored, I am editing it
+    # @reply isn't set correctly at this point so I update it to be the reply found by the first multi-reply element's ID
     @multi_replies_params.present? && (@reply = Reply.find_by(id: @multi_replies_params.first["id"]))
   end
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -84,41 +84,6 @@ class RepliesController < WritableController
     reply.user = current_user
     process_npc(reply, permitted_character_params)
 
-    if reply.post.present?
-      last_seen_reply_order = reply.post.last_seen_reply_for(current_user).try(:reply_order)
-      @unseen_replies = reply.post.replies.ordered.paginate(page: 1, per_page: 10)
-      if last_seen_reply_order.present?
-        @unseen_replies = @unseen_replies.where('reply_order > ?', last_seen_reply_order)
-        @audits = Audited::Audit.where(auditable_id: @unseen_replies.map(&:id)).group(:auditable_id).count
-      end
-      most_recent_unseen_reply = @unseen_replies.last
-
-      if params[:allow_dupe].blank?
-        last_by_user = reply.post.replies.where(user_id: reply.user_id).ordered.last
-        match_attrs = ['content', 'icon_id', 'character_id', 'character_alias_id']
-        if last_by_user.present? && last_by_user.attributes.slice(*match_attrs) == reply.attributes.slice(*match_attrs)
-          flash.now[:error] = "This looks like a duplicate. Did you attempt to post this twice? Please resubmit if this was intentional."
-          @allow_dupe = true
-          if most_recent_unseen_reply.nil? || (most_recent_unseen_reply.id == last_by_user.id && @unseen_replies.count == 1)
-            preview_reply(reply)
-          else
-            draft = make_draft(false)
-            preview_reply(ReplyDraft.reply_from_draft(draft))
-          end
-          return
-        end
-      end
-
-      if most_recent_unseen_reply.present?
-        reply.post.mark_read(current_user, at_time: reply.post.read_time_for(@unseen_replies))
-        num = @unseen_replies.count
-        pluraled = num > 1 ? "have been #{num} new replies" : "has been 1 new reply"
-        flash.now[:error] = "There #{pluraled} since you last viewed this post."
-        draft = make_draft
-        preview_reply(ReplyDraft.reply_from_draft(draft)) and return
-      end
-    end
-
     if params[:button_add_more]
       # If they click "Add More", fetch the existing array of multi replies if present and add the current permitted_params to that list
       add_to_multi_reply(reply, permitted_params)
@@ -319,6 +284,45 @@ class RepliesController < WritableController
     @multi_replies << new_reply if new_reply.present?
 
     first_reply = @multi_replies.first
+    replies_post = first_reply.post
+    if replies_post.present?
+      # Logic to check for reply duplication and unseen replies
+      last_seen_reply_order = replies_post.last_seen_reply_for(current_user).try(:reply_order)
+      @unseen_replies = replies_post.replies.ordered.paginate(page: 1, per_page: 10)
+      if last_seen_reply_order.present?
+        @unseen_replies = @unseen_replies.where('reply_order > ?', last_seen_reply_order)
+        @audits = Audited::Audit.where(auditable_id: @unseen_replies.map(&:id)).group(:auditable_id).count
+      end
+      most_recent_unseen_reply = @unseen_replies.last
+
+      if params[:allow_dupe].blank?
+        # Confirm that the user really wants the first of their new replies to match the latest reply on the thread
+        last_by_user = replies_post.replies.where(user_id: first_reply.user_id).ordered.last
+        match_attrs = ['content', 'icon_id', 'character_id', 'character_alias_id']
+        if last_by_user.present? && last_by_user.attributes.slice(*match_attrs) == first_reply.attributes.slice(*match_attrs)
+          flash.now[:error] = "This looks like a duplicate. Did you attempt to post this twice? Please resubmit if this was intentional."
+          @allow_dupe = true
+          if most_recent_unseen_reply.nil? || (most_recent_unseen_reply.id == last_by_user.id && @unseen_replies.count == 1)
+            preview_reply(first_reply)
+          else
+            draft = make_draft(false)
+            preview_reply(ReplyDraft.reply_from_draft(draft))
+          end
+          return
+        end
+      end
+
+      if most_recent_unseen_reply.present?
+        # Show a list of unseen replies before posting a new one
+        replies_post.mark_read(current_user, at_time: replies_post.read_time_for(@unseen_replies))
+        num = @unseen_replies.count
+        pluraled = num > 1 ? "have been #{num} new replies" : "has been 1 new reply"
+        flash.now[:error] = "There #{pluraled} since you last viewed this post."
+        draft = make_draft
+        preview_reply(ReplyDraft.reply_from_draft(draft)) and return
+      end
+    end
+
     begin
       Reply.transaction { @multi_replies.each(&:save!) }
     rescue ActiveRecord::RecordInvalid => e

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -281,7 +281,10 @@ class RepliesController < WritableController
   end
 
   def post_replies(new_reply: nil)
-    @multi_replies << new_reply if new_reply.present?
+    if new_reply.present?
+      @multi_replies << new_reply
+      @multi_replies_params << permitted_params
+    end
 
     first_reply = @multi_replies.first
     replies_post = first_reply.post

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -294,8 +294,13 @@ class RepliesController < WritableController
 
     # Set up editor
     @post = reply.post
-    empty_reply_hash = permitted_params.permit(:character_id, :icon_id, :character_alias_id)
+    empty_reply_hash = permitted_params.permit(:character_id, :character_alias_id)
     @reply = @post.build_new_reply_for(current_user, empty_reply_hash)
+    if @reply.character_id.nil?
+      @reply.icon_id = current_user.avatar_id
+    else
+      @reply.icon_id = @reply.character.default_icon.try(:id)
+    end
     @reply.editor_mode = reply.editor_mode
     @adding_to_multi_reply = true
     @audits = {}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -192,8 +192,8 @@ class Post < ApplicationRecord
         .where.not(character_id: recent_ids)
         .limit(count)
         .group('character_id')
-        .select('DISTINCT character_id, MAX(id)')
-        .order(Arel.sql('MAX(id) desc'))
+        .select('DISTINCT character_id, MAX(created_at)')
+        .order(Arel.sql('MAX(created_at) desc'))
         .pluck(:character_id)
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -151,12 +151,7 @@ class Post < ApplicationRecord
       reply.character_id = user.active_character_id
     end
 
-    if reply.character_id.nil?
-      reply.icon_id = user.avatar_id
-    else
-      reply.icon_id = reply.character.default_icon.try(:id)
-    end
-
+    reply.assign_default_icon(user)
     reply
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -178,15 +178,24 @@ class Post < ApplicationRecord
     @last_seen = reply
   end
 
-  def recent_characters_for(user, count)
-    # fetch the (count) most recent non-nil character_ids for user in post
-    recent_ids = replies.where(user_id: user.id)
-      .where.not(character_id: nil)
-      .limit(count)
-      .group('character_id')
-      .select('DISTINCT character_id, MAX(id)')
-      .order(Arel.sql('MAX(id) desc'))
-      .pluck(:character_id)
+  def recent_characters_for(user, count, multi_replies_params: nil)
+    # fetch the (count) most recent non-nil character_ids for user in post, including those being added by multi-replies
+    recent_ids = []
+    if multi_replies_params
+      recent_ids = multi_replies_params.reverse.pluck(:character_id).compact_blank.uniq.take(count).map(&:to_i)
+      count -= recent_ids.length
+    end
+
+    if count > 0
+      recent_ids += replies.where(user_id: user.id)
+        .where.not(character_id: nil)
+        .where.not(character_id: recent_ids)
+        .limit(count)
+        .group('character_id')
+        .select('DISTINCT character_id, MAX(id)')
+        .order(Arel.sql('MAX(id) desc'))
+        .pluck(:character_id)
+    end
 
     # add the post's character_id to the last one if it's not over the limit
     recent_ids << character_id if character_id.present? && user_id == user.id && recent_ids.length < count && recent_ids.exclude?(character_id)

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -55,6 +55,14 @@ class Reply < ApplicationRecord
     bookmarks.find_by(user_id: user.id)
   end
 
+  def assign_default_icon(user)
+    if character_id.nil?
+      self.icon_id = user.avatar_id
+    else
+      self.icon_id = character.default_icon&.id
+    end
+  end
+
   private
 
   def set_last_reply

--- a/app/views/replies/_single.haml
+++ b/app/views/replies/_single.haml
@@ -1,4 +1,4 @@
--# locals: ( reply:, hide_footer: false, split_ui: false )
+-# locals: ( reply:, hide_footer: false, hide_post_edit_box: false, split_ui: false )
 
 - if reply.is_a?(Post)
   - write = 'post-post'.freeze
@@ -30,7 +30,7 @@
         - else
           .spacer-alt
         .post-author= user_mem_link(reply.user_id, reply.username, reply.user_deleted?)
-    - if reply.id.present?
+    - if reply.id.present? && !hide_post_edit_box
       .post-edit-box
         - if split_ui
           - if reply.is_a?(Reply)

--- a/app/views/replies/_write.haml
+++ b/app/views/replies/_write.haml
@@ -72,4 +72,4 @@
       %br
     = render 'writable/editor_help', editor_location: 'reply'
 
-= render 'writable/editor', writable: reply
+= render 'writable/editor', writable: reply, multi_replies_params: multi_replies_params

--- a/app/views/replies/preview.haml
+++ b/app/views/replies/preview.haml
@@ -20,6 +20,7 @@
     = render 'replies/single', reply: reply, hide_footer: true, hide_post_edit_box: true
   = form_for @reply, html: { id: 'post_form' } do
     = hidden_field_tag :multi_replies_json, @multi_replies_params.to_json
+    = hidden_field_tag :allow_dupe, @allow_dupe
     = submit_tag (multi_reply_new ? 'Post Previewed' : 'Save Previewed'), class: 'button', id: 'submit_previewed_multi_reply_button', name: 'button_submit_previewed_multi_reply', data: { disable_with: 'Saving...', confirm: 'The reply currently in the editor will not be posted. Continue?' }
     %br
     %br

--- a/app/views/replies/preview.haml
+++ b/app/views/replies/preview.haml
@@ -17,7 +17,7 @@
   - else
     .content-header Editing reply and adding more
   - @multi_replies.each do |reply|
-    = render 'replies/single', reply: reply, hide_footer: true
+    = render 'replies/single', reply: reply, hide_footer: true, hide_post_edit_box: true
   = form_for @reply, html: { id: 'post_form' } do
     = hidden_field_tag :multi_replies_json, @multi_replies_params.to_json
     = submit_tag (multi_reply_new ? 'Post Previewed' : 'Save Previewed'), class: 'button', id: 'submit_previewed_multi_reply_button', name: 'button_submit_previewed_multi_reply', data: { disable_with: 'Saving...', confirm: 'The reply currently in the editor will not be posted. Continue?' }

--- a/app/views/writable/_editor.haml
+++ b/app/views/writable/_editor.haml
@@ -1,4 +1,4 @@
--# locals: ( writable: )
+-# locals: ( writable:, multi_replies_params: nil )
 
 - character_galleries = writable.character.galleries.ordered if writable.character && current_user.icon_picker_grouping? && writable.character.galleries.count > 1
 #post-editor.padding-10
@@ -44,7 +44,7 @@
         .post-char-access
           - char_count = 10
           - char_count -= 1 if current_user.show_user_in_switcher?
-          - recent_characters = writable.post.try(:recent_characters_for, current_user, char_count)
+          - recent_characters = writable.post.try(:recent_characters_for, current_user, char_count, multi_replies_params: multi_replies_params)
           - if current_user.show_user_in_switcher?
             = user_icon_tag(current_user)
           - if recent_characters.present?

--- a/spec/system/replies/edit_spec.rb
+++ b/spec/system/replies/edit_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe "Editing replies" do
     end
   end
 
-  context "Using the multi reply editor" do
-    scenario "to split a reply", :js do
+  context "using the multi reply editor" do
+    scenario "works", :js do
       user = login
       user.update!(default_editor: 'html')
 
@@ -239,6 +239,127 @@ RSpec.describe "Editing replies" do
       expect(page).to have_selector('.post-container', count: 8)
       expect(page).to have_selector('.post-content', exact_text: 'other text 1', count: 2)
       expect(page).to have_selector('.post-content', exact_text: 'other text 3', count: 2)
+    end
+
+    scenario "interacts correctly with the quick switcher", :js do
+      user = login
+      user.update!(default_editor: 'html')
+
+      # Create characters and aliases
+      char1 = create(:character, user: user, name: "char1")
+      char1_alias = create(:alias, character: char1, name: "char1_alias")
+      char2 = create(:character, user: user, name: "char2")
+      char2_alias = create(:alias, character: char2, name: "char2_alias")
+      char3 = create(:character, user: user, name: "char3")
+      char3_alias = create(:alias, character: char3, name: "char3_alias")
+      char4 = create(:character, user: user, name: "char4")
+      char4_alias = create(:alias, character: char4, name: "char4_alias")
+
+      # Create replies with those characters and aliases
+      post = create(:post)
+      reply = create(:reply, post: post, user: user)
+      create(:reply, post: post, user: user, character: char1)
+      create(:reply, post: post, user: user, character: char2, character_alias: char2_alias)
+      create(:reply, post: post, user: user, character: char3)
+      create(:reply, post: post, user: user, character: char3, character_alias: char3_alias)
+
+      visit reply_path(reply)
+      within(find_reply_on_page(reply)) do
+        click_link 'Edit'
+      end
+
+      # Check that the quick switcher has the characters in the right orders
+      switcher_chars = within('.post-char-access') do
+        switcher_chars = all('.char-access-icon')
+        expect(switcher_chars.size).to eq(4)
+
+        expected_ids = ["", char3.id.to_s, char2.id.to_s, char1.id.to_s]
+        actual_ids = switcher_chars.map { |img| img[:'data-character-id'] }
+
+        expect(actual_ids).to eq(expected_ids)
+
+        switcher_chars
+      end
+
+      # Check that all aliases are selected correctly
+      switcher_chars[1].click
+      within('.post-character') { expect(find_by_id('name').text).to eq(char3_alias.name) }
+      switcher_chars[2].click
+      within('.post-character') { expect(find_by_id('name').text).to eq(char2_alias.name) }
+      switcher_chars[3].click
+      within('.post-character') do
+        expect(find_by_id('name').text).to eq(char1.name)
+
+        find_by_id('swap-alias').click
+        find_by_id('select2-character_alias-container').click
+      end
+
+      # Change the character's alias and submit to multi-reply editor
+      page.find('li', exact_text: char1_alias.name).click
+      click_button "Add More Replies"
+
+      within('#post-editor') do
+        # Check that the switcher has the correct characters in the right order
+        switcher_chars = within('.post-char-access') do
+          switcher_chars = all('.char-access-icon')
+          expect(switcher_chars.size).to eq(4)
+
+          expected_ids = ["", char1.id.to_s, char3.id.to_s, char2.id.to_s]
+          actual_ids = switcher_chars.map { |img| img[:'data-character-id'] }
+
+          expect(actual_ids).to eq(expected_ids)
+
+          switcher_chars
+        end
+
+        # Check that alias is selected correctly
+        within('.post-character') { expect(find_by_id('name').text).to eq(char1_alias.name) }
+        switcher_chars[2].click
+        within('.post-character') { expect(find_by_id('name').text).to eq(char3_alias.name) }
+        switcher_chars[1].click
+        within('.post-character') { expect(find_by_id('name').text).to eq(char1_alias.name) }
+
+        # Include a new character
+        within('.post-author') do
+          find_by_id('swap-character').click
+          find_by_id('select2-active_character-container').click
+        end
+      end
+      page.find('li', exact_text: char4.name).click
+      click_button "HTML" # Just to force the editor to update
+      click_button "Add More Replies"
+
+      within('#post-editor') do
+        # Check that the switcher has the correct characters in the right order
+        switcher_chars = within('.post-char-access') do
+          switcher_chars = all('.char-access-icon')
+          expect(switcher_chars.size).to eq(5)
+
+          expected_ids = ["", char4.id.to_s, char1.id.to_s, char3.id.to_s, char2.id.to_s]
+          actual_ids = switcher_chars.map { |img| img[:'data-character-id'] }
+
+          expect(actual_ids).to eq(expected_ids)
+
+          switcher_chars
+        end
+
+        # Check that aliases are selected correctly
+        within('.post-character') { expect(find_by_id('name').text).to eq(char4.name) }
+        switcher_chars[2].click
+        within('.post-character') { expect(find_by_id('name').text).to eq(char1_alias.name) }
+        switcher_chars[1].click
+        within('.post-character') do
+          expect(find_by_id('name').text).to eq(char4.name)
+
+          find_by_id('swap-alias').click
+          find_by_id('select2-character_alias-container').click
+        end
+      end
+
+      # Change the character's alias and submit to multi-reply editor
+      page.find('li', exact_text: char4_alias.name).click
+      click_button "Add More Replies"
+      within('#post-editor .post-character') { expect(find_by_id('name').text).to eq(char4_alias.name) }
     end
 
     scenario "handles NPC saving errors", :js do

--- a/spec/system/replies/new_spec.rb
+++ b/spec/system/replies/new_spec.rb
@@ -255,126 +255,180 @@ RSpec.describe "Creating replies" do
     end
   end
 
-  scenario "User creates multiple replies at once", :js do
-    post = create(:post, subject: 'Sample post')
+  context "using the multi reply editor" do
+    scenario "works", :js do
+      post = create(:post, subject: 'Sample post')
 
-    user = login
-    character = create(:character, user: user)
-    npc_name = "Jade"
-    visit post_path(post)
+      user = login
+      character = create(:character, user: user)
+      npc_name = "Jade"
+      visit post_path(post)
 
-    # Use "Post Previewed" button
-    page.find('.post-expander', text: 'Join Thread').click
-    page.find('img[title="Choose Character"]').click
-    click_button 'Character'
-    page.find_by_id('select2-active_character-container').click
-    find_all("li", text: character.name).first.click
-    click_button "HTML"
-    within('#post-editor') do
-      fill_in id: "reply_content", with: "test reply 1"
-      click_button "Add More Replies"
-    end
-
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_selector('.post-container', count: 1)
-    expect(page).to have_selector('#post-editor')
-    within('#post-editor') do
-      expect(page).to have_selector('#name', exact_text: character.name)
+      # Use "Post Previewed" button
+      page.find('.post-expander', text: 'Join Thread').click
       page.find('img[title="Choose Character"]').click
-      click_button 'NPC'
-    end
-    page.find('.select2-selection__rendered', exact_text: 'Select NPC or type to create').click
-    page.find('.select2-container--open .select2-search__field').set(npc_name)
-    page.find('li', exact_text: "Create New: #{npc_name}").click
-    expect(page).to have_selector('#name', exact_text: npc_name)
+      click_button 'Character'
+      page.find_by_id('select2-active_character-container').click
+      find_all("li", text: character.name).first.click
+      click_button "HTML"
+      within('#post-editor') do
+        fill_in id: "reply_content", with: "test reply 1"
+        click_button "Add More Replies"
+      end
 
-    fill_in id: "reply_content", with: "test reply 2"
-    click_button "Add More Replies"
-
-    expect(page).to have_no_selector('.error')
-    within(".success") { expect(page).to have_text("Your new NPC has been persisted!") }
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_selector('.post-container', count: 2)
-    expect(page).to have_selector('#post-editor')
-    within('#post-editor') do
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_selector('.post-container', count: 1)
+      expect(page).to have_selector('#post-editor')
+      within('#post-editor') do
+        expect(page).to have_selector('#name', exact_text: character.name)
+        page.find('img[title="Choose Character"]').click
+        click_button 'NPC'
+      end
+      page.find('.select2-selection__rendered', exact_text: 'Select NPC or type to create').click
+      page.find('.select2-container--open .select2-search__field').set(npc_name)
+      page.find('li', exact_text: "Create New: #{npc_name}").click
       expect(page).to have_selector('#name', exact_text: npc_name)
-    end
-    fill_in id: "reply_content", with: "test reply 3"
-    click_button "Preview Current"
 
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_selector('.content-header', exact_text: 'Previewing')
-    expect(page).to have_selector('.post-container', count: 3)
-    expect(page).to have_text("test reply 3", count: 2)
-    click_button "Add More Replies"
-
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_no_selector('.content-header', exact_text: 'Previewing')
-    expect(page).to have_selector('.post-container', count: 3)
-    expect(page).to have_text("test reply 3", count: 1)
-    fill_in id: "reply_content", with: "test reply 4"
-    accept_alert { click_button "Post Previewed" }
-
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.success', exact_text: 'Replies posted.')
-    expect(page).to have_selector('.post-container', count: 4)
-    expect(page).to have_text("test reply 1")
-    expect(page).to have_text("test reply 2")
-    expect(page).to have_text("test reply 3")
-    expect(page).to have_no_text("test reply 4")
-
-    # Use "Post All" button
-    within('#post-editor') do
-      click_button "HTML"
-      fill_in id: "reply_content", with: "test reply 5"
+      fill_in id: "reply_content", with: "test reply 2"
       click_button "Add More Replies"
-    end
 
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_selector('.post-container', count: 1)
-    expect(page).to have_selector('#post-editor')
-    fill_in id: "reply_content", with: "test reply 6"
-    click_button "Add More Replies"
+      expect(page).to have_no_selector('.error')
+      within(".success") { expect(page).to have_text("Your new NPC has been persisted!") }
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_selector('.post-container', count: 2)
+      expect(page).to have_selector('#post-editor')
+      within('#post-editor') do
+        expect(page).to have_selector('#name', exact_text: npc_name)
+      end
+      fill_in id: "reply_content", with: "test reply 3"
+      click_button "Preview Current"
 
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_selector('.post-container', count: 2)
-    expect(page).to have_selector('#post-editor')
-    fill_in id: "reply_content", with: "test reply 7"
-    click_button "Post All"
-
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.success', exact_text: 'Replies posted.')
-    expect(page).to have_selector('.post-container', count: 7)
-    expect(page).to have_no_text("test reply 4")
-    expect(page).to have_text("test reply 5")
-    expect(page).to have_text("test reply 6")
-    expect(page).to have_text("test reply 7")
-
-    # Discard replies
-    within('#post-editor') do
-      click_button "HTML"
-      fill_in id: "reply_content", with: "test reply 8"
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_selector('.content-header', exact_text: 'Previewing')
+      expect(page).to have_selector('.post-container', count: 3)
+      expect(page).to have_text("test reply 3", count: 2)
       click_button "Add More Replies"
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_no_selector('.content-header', exact_text: 'Previewing')
+      expect(page).to have_selector('.post-container', count: 3)
+      expect(page).to have_text("test reply 3", count: 1)
+      fill_in id: "reply_content", with: "test reply 4"
+      accept_alert { click_button "Post Previewed" }
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.success', exact_text: 'Replies posted.')
+      expect(page).to have_selector('.post-container', count: 4)
+      expect(page).to have_text("test reply 1")
+      expect(page).to have_text("test reply 2")
+      expect(page).to have_text("test reply 3")
+      expect(page).to have_no_text("test reply 4")
+
+      # Use "Post All" button
+      within('#post-editor') do
+        click_button "HTML"
+        fill_in id: "reply_content", with: "test reply 5"
+        click_button "Add More Replies"
+      end
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_selector('.post-container', count: 1)
+      expect(page).to have_selector('#post-editor')
+      fill_in id: "reply_content", with: "test reply 6"
+      click_button "Add More Replies"
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_selector('.post-container', count: 2)
+      expect(page).to have_selector('#post-editor')
+      fill_in id: "reply_content", with: "test reply 7"
+      click_button "Post All"
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.success', exact_text: 'Replies posted.')
+      expect(page).to have_selector('.post-container', count: 7)
+      expect(page).to have_no_text("test reply 4")
+      expect(page).to have_text("test reply 5")
+      expect(page).to have_text("test reply 6")
+      expect(page).to have_text("test reply 7")
+
+      # Discard replies
+      within('#post-editor') do
+        click_button "HTML"
+        fill_in id: "reply_content", with: "test reply 8"
+        click_button "Add More Replies"
+      end
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
+      expect(page).to have_selector('.post-container', count: 1)
+      expect(page).to have_selector('#post-editor')
+      fill_in id: "reply_content", with: "test reply 9"
+      click_button "Add More Replies"
+      accept_alert { click_button "Discard Replies" }
+
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.success', exact_text: "Replies discarded.")
+      expect(page).to have_selector('.post-container', count: 7)
+      expect(page).to have_no_text("test reply 8")
+      expect(page).to have_no_text("test reply 9")
     end
 
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.content-header', exact_text: 'Adding multiple replies')
-    expect(page).to have_selector('.post-container', count: 1)
-    expect(page).to have_selector('#post-editor')
-    fill_in id: "reply_content", with: "test reply 9"
-    click_button "Add More Replies"
-    accept_alert { click_button "Discard Replies" }
+    scenario "shows unseen and duplicate replies warnings", :js do
+      user = login
+      user.update!(default_editor: 'html')
 
-    expect(page).to have_no_selector('.error')
-    expect(page).to have_selector('.success', exact_text: "Replies discarded.")
-    expect(page).to have_selector('.post-container', count: 7)
-    expect(page).to have_no_text("test reply 8")
-    expect(page).to have_no_text("test reply 9")
+      post = create(:post, subject: 'Sample post')
+      reply = create(:reply, user: user, post: post, content: "reply to dupe")
+      visit post_path(post)
+
+      # Will try to add a reply whose content is duplicated
+      within('#post-editor') do
+        fill_in id: "reply_content", with: reply.content
+        click_button "Add More Replies"
+      end
+      expect(page).to have_no_selector('.error')
+
+      within('#post-editor') do
+        fill_in 'reply_content', with: 'new reply 1'
+        click_button 'Add More Replies'
+      end
+      expect(page).to have_no_selector('.error')
+
+      within('#post-editor') do
+        fill_in 'reply_content', with: 'new reply 2'
+        click_button 'Post All'
+      end
+      expect(page).to have_selector('.error',
+        text: 'This looks like a duplicate. Did you attempt to post this twice? Please resubmit if this was intentional.',)
+
+      accept_alert { click_button "Post Previewed" }
+      expect(page).to have_selector('.post-content', exact_text: reply.content, count: 2)
+      expect(page).to have_selector('.post-content', exact_text: 'new reply 1', count: 1)
+      expect(page).to have_selector('.post-content', exact_text: 'new reply 2', count: 1)
+
+      # Will add more unseen replies after clicking "Add More Replies"
+      within('#post-editor') do
+        fill_in id: "reply_content", with: 'new reply 3'
+        click_button "Add More Replies"
+      end
+      create(:reply, post: post)
+
+      within('#post-editor') do
+        fill_in 'reply_content', with: 'new reply 4'
+        click_button 'Post All'
+      end
+      expect(page).to have_selector('.error', text: "There has been 1 new reply since you last viewed this post.")
+
+      accept_alert { click_button "Post Previewed" }
+      expect(page).to have_no_selector('.error')
+      expect(page).to have_selector('.post-content', exact_text: 'new reply 3', count: 1)
+      expect(page).to have_selector('.post-content', exact_text: 'new reply 4', count: 1)
+    end
   end
 
   scenario "User tries to reply to locked post" do


### PR DESCRIPTION
- Make the quick selector behave in intuitive ways, including adding new characters in the middle of the multi replies.
- Make the alias shown when selecting a character correctly fetch the alias used in the multi replies.
- Use the correct icon on the blank reply textbox (i.e. a character's default) rather than the last icon that was used.
- Make the "there are unseen replies" and "this reply might be a duplicate" warnings not show up when splitting an existing reply.
- Make the "this reply might be a duplicate" warning on adding a new set of multi replies match the first reply being added not the last.
- Remove the reply buttons (permalink, edit, etc) from the top reply of a list of multi replies.