### PR TITLE
Add ExceptionNotification on Resque failure

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -28,3 +28,11 @@ end
 # require 'resque/failure/redis'
 # Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis]
 # Resque::Failure.backend = Resque::Failure::MultipleWithRetrySuppression
+
+# logs Resque failures and sends them to ExceptionNotification
+require 'resque/failure/multiple'
+require 'resque/failure/redis'
+require 'exception_notification/resque'
+
+Resque::Failure::Multiple.classes = [Resque::Failure::Redis, ExceptionNotification::Resque]
+Resque::Failure.backend = Resque::Failure::Multiple


### PR DESCRIPTION
As per https://github.com/smartinez87/exception_notification/blob/master/lib/generators/exception_notification/templates/exception_notification.rb.erb#L7

Not 100% sure how to avoid this potentially entering an infinite loop if something goes wrong with ExceptionNotifier itself (does it send async?), but would be good to have something like this to make sure we get notifications when emails are broken.