### PR TITLE
Upgrade bundler, normalize platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
   && apt install -y chromium \
   && apt-get clean
 
-ARG bundler_version=2.5.6
+ARG bundler_version=2.6.2
 
 RUN gem install bundler -v $bundler_version
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,8 @@ GEM
       railties (>= 5.0.0)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
@@ -193,6 +195,9 @@ GEM
       i18n (>= 0.7)
       multi_json
       request_store (>= 1.0)
+    google-protobuf (4.29.2)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.29.2-aarch64-linux)
       bigdecimal
       rake (>= 13)
@@ -296,6 +301,10 @@ GEM
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.2-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.2-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.2-arm-linux-musl)
       racc (~> 1.4)
     nokogiri (1.18.2-arm64-darwin)
       racc (~> 1.4)
@@ -461,6 +470,10 @@ GEM
       google-protobuf (~> 4.28)
     sass-embedded (1.83.0-aarch64-linux-musl)
       google-protobuf (~> 4.28)
+    sass-embedded (1.83.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.83.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.28)
     sass-embedded (1.83.0-arm64-darwin)
       google-protobuf (~> 4.28)
     sass-embedded (1.83.0-x86_64-darwin)
@@ -546,11 +559,16 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  aarch64-linux
   aarch64-linux-gnu
   aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
   arm64-darwin
   x86_64-darwin
-  x86_64-linux
+  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES
@@ -631,4 +649,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.5.6
+   2.6.2


### PR DESCRIPTION
https://bundler.io/blog/2024/12/19/bundler-v2-6.html

https://devcenter.heroku.com/articles/ruby-support-reference#bundler-version-configuration-on-cedar