### PR TITLE
Use button instead of input for draft deletion

### DIFF
--- a/app/views/replies/_write.haml
+++ b/app/views/replies/_write.haml
@@ -36,7 +36,7 @@
         - if reply.new_record?
           = submit_tag "Save Draft", class: 'button', id: 'draft_button', name: 'button_draft', formaction: drafts_path, data: { disable_with: 'Drafting...' }
         - if @draft.present?
-          = submit_tag "Delete Draft", class: 'button', id: 'delete_draft_button', name: 'button_delete_draft', formaction: draft_path(@draft), formmethod: :delete, data: { disable_with: 'Deleting...', confirm: "Delete draft?" }
+          = button_tag "Delete Draft", class: 'button', id: 'delete_draft_button', name: '_method', value: 'delete', formaction: draft_path(@draft), data: { disable_with: 'Deleting...', confirm: "Delete draft?" }
       - else
         = submit_tag (multi_reply_new ? 'Post All' : 'Save All'), class: 'button', id: 'submit_button', data: { disable_with: 'Saving...' }
         = submit_tag "Preview Current", class: 'button', id: 'preview_button', name: 'button_preview', data: { disable_with: 'Previewing...' }


### PR DESCRIPTION
formmethod doesn't support the DELETE method, so Rails overloads values in the button to determine method, but we can't pass the correct values using a submit input so switching to button. Specifically, the request must send a parameter "_method" with a value of "delete", but the submit input uses the value to decide what text to display, so we'd have to display "delete" to our users instead of "Delete Draft" which is strictly worse than using the button.

Tested on staging, works there.