### PR TITLE
Add SELinux security labels to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ x-svc: &svc
     - postgres
     - minio
   volumes:
-    - .:/code
+    - .:/code:z
     - bundler-volume:/usr/local/bundle
     - webdrivers:/root/.webdrivers # caches webdrivers for selenium feature specs
 


### PR DESCRIPTION
On some Linux systems (cough, mine, cough), the SELinux security module uses file tags in order to prevent unauthorized containerized applications from accessing a user's files. This breaks the docker-compose setup used for development. This commit adds the :z option to the bind mount in docker-compose, which instructs docker to add appropriate SELinux security tags to the bind-mount inside the container when necessary.

This shouldn't impact any systems where the configuration was working, but anyone else on a Fedora-derived Linux distribution should now be able to use docker compose without issue.