### PR TITLE
Add includes to reduce N+1 queries

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -27,6 +27,7 @@ class BookmarksController < ApplicationController
 
     @search_results = @search_results
       .joins(:post)
+      .includes([:icon])
       .order('posts.subject, replies.created_at, posts.id')
       .joins(:user)
       .left_outer_joins(:character)

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -167,9 +167,10 @@ class CharactersController < ApplicationController
   def replace
     @page_title = 'Replace Character: ' + @character.name
     if @character.template
-      @alts = @character.template.characters
+      @alts = @character.template.characters.includes([:aliases, :default_icon])
     else
-      @alts = @character.user.characters.where(template_id: nil)
+      @alts = @character.user.characters.includes([:aliases, :default_icon])
+                .where(template_id: nil)
     end
     @alts -= [@character] unless @alts.size <= 1 || @character.aliases.exists?
     use_javascript('icons')

--- a/app/controllers/icons_controller.rb
+++ b/app/controllers/icons_controller.rb
@@ -56,7 +56,7 @@ class IconsController < UploadingController
       @times_used = (posts_using.count + replies_using.count)
       @posts_used = (posts_using.pluck(:id) + replies_using.select(:post_id).distinct.pluck(:post_id)).uniq.count
     end
-    @galleries = @icon.galleries.ordered_by_name
+    @galleries = @icon.galleries.includes([:default_icon]).ordered_by_name
     @meta_og = og_data
     response.headers['X-Robots-Tag'] = 'noindex' if params[:view]
   end

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -13,7 +13,7 @@ class RepliesController < WritableController
     @page_title = 'Search Replies'
     use_javascript('search')
 
-    @post = Post.find_by(id: params[:post_id]) if params[:post_id].present?
+    @post = Post.find_by(id: params[:post_id]).includes([:audits]) if params[:post_id].present?
     @icon = Icon.find_by(id: params[:icon_id]) if params[:icon_id].present?
 
     if @post&.visible_to?(current_user)

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -78,7 +78,8 @@ class TemplatesController < ApplicationController
 
   def editor_setup
     @selectable_characters = @template.try(:characters) || []
-    @selectable_characters += current_user.characters.where(template_id: nil).ordered
+    @selectable_characters += current_user.characters.includes([:default_icon])
+                                .where(template_id: nil).ordered
     @selectable_characters.uniq!
     @character_ids = permitted_params[:character_ids] if permitted_params.key?(:character_ids)
     @character_ids ||= @template.try(:character_ids) || []

--- a/app/views/writable/_editor.haml
+++ b/app/views/writable/_editor.haml
@@ -1,6 +1,6 @@
 -# locals: ( writable:, multi_replies_params: nil )
 
-- character_galleries = writable.character.galleries.ordered if writable.character && current_user.icon_picker_grouping? && writable.character.galleries.count > 1
+- character_galleries = writable.character.galleries.includes([:icons]).ordered if writable.character && current_user.icon_picker_grouping? && writable.character.galleries.count > 1
 #post-editor.padding-10
   .post-info-box
     #current-icon-holder.post-icon


### PR DESCRIPTION
I have no particular insight on whether this will _help_ with the current performance problems, but I don't see how it can hurt.

I used Bullet to look for places where the app was making N+1 queries — making a subsequent database request for every item in a collection. Ten of those places turned out to be too complicated for me to figure out how to fix without making deep changes to the code. This PR has everything _else_, i.e., everything that was easy to fix.

This will have slightly higher memory usage because more will be pulled from the DB, but not by very much. And since it will be pulled into a signal array that can get garbage collected at once, instead of pulled as many separate database transactions, it should be less work for the site overall.