### PR TITLE
Scope reply audit lookups by auditable_type

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -172,7 +172,11 @@ class PostsController < WritableController
     audit_ids = @post.associated_audits.where(action: 'destroy').where(auditable_type: 'Reply') # all destroyed replies
     audit_ids = audit_ids.joins('LEFT JOIN replies ON replies.id = audits.auditable_id').where(replies: { id: nil }) # not restored
     audit_ids = audit_ids.group(:auditable_id).pluck(Arel.sql('MAX(audits.id)')) # only most recent per reply
-    @deleted_audits = Audited::Audit.where(id: audit_ids).paginate(per_page: 1, page: page)
+    # `audit_ids` is already restricted to Reply audits above, so this scope
+    # cannot change the result today. It is stated anyway: an audit id is only
+    # meaningful together with its type, and leaving that to be inferred three
+    # lines up is how the bug this fixes was written in the first place.
+    @deleted_audits = Audited::Audit.where(id: audit_ids, auditable_type: 'Reply').paginate(per_page: 1, page: page)
 
     return unless @deleted_audits.present?
 

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -137,7 +137,7 @@ class RepliesController < WritableController
   end
 
   def restore
-    audit = Audited::Audit.where(action: 'destroy').order(id: :desc).find_by(auditable_id: params[:id])
+    audit = Audited::Audit.where(action: 'destroy').order(id: :desc).find_by(auditable_type: 'Reply', auditable_id: params[:id])
     unless audit
       flash[:error] = "Reply could not be found."
       redirect_to continuities_path and return
@@ -149,7 +149,7 @@ class RepliesController < WritableController
     end
 
     new_reply = Reply.new(audit.audited_changes)
-    new_reply.created_at = Audited::Audit.order(id: :asc).find_by(action: 'create', auditable_id: params[:id]).created_at
+    new_reply.created_at = Audited::Audit.order(id: :asc).find_by(action: 'create', auditable_type: 'Reply', auditable_id: params[:id]).created_at
     unless new_reply.editable_by?(current_user)
       flash[:error] = "You do not have permission to modify this reply."
       redirect_to post_path(new_reply.post) and return
@@ -300,7 +300,7 @@ class RepliesController < WritableController
       @unseen_replies = replies_post.replies.ordered.paginate(page: 1, per_page: 10)
       if last_seen_reply_order.present?
         @unseen_replies = @unseen_replies.where('reply_order > ?', last_seen_reply_order)
-        @audits = Audited::Audit.where(auditable_id: @unseen_replies.map(&:id)).group(:auditable_id).count
+        @audits = Audited::Audit.where(auditable_type: 'Reply', auditable_id: @unseen_replies.map(&:id)).group(:auditable_id).count
       end
       most_recent_unseen_reply = @unseen_replies.last
 

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -97,7 +97,7 @@ class WritableController < ApplicationController
     redirect_to post_path(@post, page: @replies.total_pages, per_page: per) and return if cur_page > @replies.total_pages
     use_javascript('paginator')
 
-    @audits = @post.associated_audits.where(auditable_id: @replies.map(&:id)).group(:auditable_id).count
+    @audits = @post.associated_audits.where(auditable_type: 'Reply', auditable_id: @replies.map(&:id)).group(:auditable_id).count
     @audits[:post] = @post.audits.count
 
     calculate_reply_bookmarks(@replies)

--- a/spec/controllers/posts/delete_history_spec.rb
+++ b/spec/controllers/posts/delete_history_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe PostsController, 'GET delete_history' do
   end
 
   def restore(reply)
-    audit = Audited::Audit.where(action: 'destroy', auditable_id: reply.id).last
+    audit = Audited::Audit.where(action: 'destroy', auditable_type: 'Reply', auditable_id: reply.id).last
     new_reply = Reply.new(audit.audited_changes)
     new_reply.is_import = true
     new_reply.skip_notify = true

--- a/spec/controllers/replies/restore_spec.rb
+++ b/spec/controllers/replies/restore_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RepliesController, 'POST restore' do
 
   it "must find the reply" do
     expect(Reply.find_by(id: 99)).to be_nil
-    expect(Audited::Audit.find_by(auditable_id: 99)).to be_nil
+    expect(Audited::Audit.find_by(auditable_type: 'Reply', auditable_id: 99)).to be_nil
     login
     post :restore, params: { id: 99 }
     expect(response).to redirect_to(continuities_url)
@@ -24,7 +24,7 @@ RSpec.describe RepliesController, 'POST restore' do
 
   it "must be a deleted reply" do
     reply = create(:reply)
-    Audited::Audit.where(action: 'create').find_by(auditable_id: reply.id).update!(action: 'destroy')
+    Audited::Audit.where(action: 'create').find_by(auditable_type: 'Reply', auditable_id: reply.id).update!(action: 'destroy')
     login_as(reply.user)
     post :restore, params: { id: 99 }
     expect(response).to redirect_to(continuities_url)


### PR DESCRIPTION
## Summary

New Relic shows `ActiveRecord::QueryCanceled` (Postgres statement timeout) 500ing `POST /replies` four times this past week. The slow-query log pins it to the audit count in the multi-reply duplication check:

```
SELECT COUNT(*) ... FROM audits WHERE auditable_id = $1 GROUP BY auditable_id
```

`audits` only has `(auditable_type, auditable_id, version)` and `(associated_type, associated_id)` indexes — a bare `auditable_id` filter can't use either, so it sequential-scans the entire audit history and times out under load, killing the user's reply submission.

Three lookups in `RepliesController` had this shape (the dupe-check group-count, and both audit lookups in `restore`). Adding `auditable_type: 'Reply'`:

- makes all three use the existing `auditable_index`, and
- fixes a latent correctness issue — bare `auditable_id` also matches **Post** audits sharing the same numeric id, so `restore` keyed off whatever same-id `destroy` audit sorted last regardless of type, and the dupe-check counts could include another model's audits.

## Testing

Covered by the existing restore/create controller specs; no behavior change for correctly-typed audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)