### PR TITLE
Do not shed logged-in readers who arrive by "remember me" cookie

### DIFF
--- a/app/middleware/anon_load_shed.rb
+++ b/app/middleware/anon_load_shed.rb
@@ -25,11 +25,17 @@ class AnonLoadShed
     @app = app
   end
 
+  # The queue-wait check comes first because it is the cheapest and by far the
+  # most common answer: in steady state nothing is saturated, so this costs one
+  # env lookup and returns. Identifying the user means building a cookie jar to
+  # verify a signature, which is only worth doing on the rare request we are
+  # otherwise about to shed. All three checks are pass-throughs, so ordering
+  # changes only the work done, never the verdict.
   def call(env)
-    return @app.call(env) if logged_in?(env)
-    return @app.call(env) if login_request?(env)
     waited = wait_seconds(env)
     return @app.call(env) if waited.nil? || waited < WAIT_THRESHOLD_SECONDS
+    return @app.call(env) if login_request?(env)
+    return @app.call(env) if logged_in?(env)
     [
       503,
       { 'Content-Type' => 'text/plain', 'Retry-After' => '30' },
@@ -40,8 +46,37 @@ class AnonLoadShed
   private
 
   def logged_in?(env)
+    session_user_id(env).present? || permanent_user_id(env).present?
+  end
+
+  def session_user_id(env)
     session = env['rack.session']
-    session && session[:user_id].present?
+    session && session[:user_id]
+  end
+
+  # Readers who ticked "remember me" carry their credential in a permanent
+  # signed cookie rather than the session: the session cookie is configured
+  # with no expiry, so it dies with the browser, and
+  # `Authentication::Web#check_permanent_user` only promotes the cookie into
+  # the session once a controller runs — which is after this middleware.
+  #
+  # Checking the session alone therefore reads a genuinely logged-in reader as
+  # anonymous on their first request after a browser restart, and they cannot
+  # retry their way out of it: a shed response never reaches the controller
+  # that would have restored their session, so every refresh sheds again for
+  # as long as the queue stays deep. Only /login, exempted above, breaks the
+  # loop.
+  #
+  # The signature is verified rather than the cookie merely being checked for
+  # presence, so a scraper cannot opt out of shedding by inventing a `user_id`
+  # cookie. Building the jar is a bare HMAC check — no database work, and no
+  # session is written, so a shed request still costs what it did before.
+  def permanent_user_id(env)
+    ActionDispatch::Request.new(env).cookie_jar.signed[:user_id]
+  rescue StandardError
+    # A malformed or unverifiable cookie is simply not a login; fall back to
+    # the session verdict rather than letting a bad cookie raise a 500.
+    nil
   end
 
   # A logged-out user has no way to become prioritized except by logging in, so

--- a/spec/middleware/anon_load_shed_spec.rb
+++ b/spec/middleware/anon_load_shed_spec.rb
@@ -10,12 +10,19 @@ RSpec.describe AnonLoadShed do
   let(:downstream) { ->(_env) { [200, {}, ['ok']] } }
   let(:middleware) { AnonLoadShed.new(downstream) }
 
-  def env(wait: nil, user_id: nil, path: '/posts')
-    {
+  # `remembered` is the user id the signed `user_id` cookie verifies to, or nil
+  # where the cookie is absent, forged or otherwise unverifiable — the jar
+  # returns nil for all three, so they are one case from here. Omitting it
+  # leaves no jar on the env at all, which is what a bare Rack env looks like.
+  def env(wait: nil, user_id: nil, path: '/posts', remembered: :no_jar)
+    base = {
       Rack::Timeout::ENV_INFO_KEY => wait && Struct.new(:wait).new(wait),
       'rack.session'              => { user_id: user_id },
       'PATH_INFO'                 => path,
     }
+    return base if remembered == :no_jar
+    jar = instance_double(ActionDispatch::Cookies::CookieJar, signed: { user_id: remembered })
+    base.merge('action_dispatch.cookies' => jar)
   end
 
   it "passes through when there is no wait info (queue depth unknown)" do
@@ -50,5 +57,26 @@ RSpec.describe AnonLoadShed do
   it "never sheds login requests, so logged-out users can still log in under load" do
     status, = middleware.call(env(wait: 30.0, path: '/login'))
     expect(status).to eq(200)
+  end
+
+  # A "remember me" reader arrives with a permanent signed cookie and no
+  # session, because the session cookie has no expiry and dies with the
+  # browser. `check_permanent_user` would restore their session, but it runs in
+  # a controller, i.e. after this middleware — so shedding them here is
+  # unrecoverable by retrying: the shed response never reaches the controller
+  # that would have promoted the cookie.
+  it "passes through a remembered user whose session cookie is gone" do
+    expect(middleware.call(env(wait: 30.0, user_id: nil, remembered: 7))).to eq([200, {}, ['ok']])
+  end
+
+  it "still sheds when the cookie is present but does not verify" do
+    status, = middleware.call(env(wait: 30.0, user_id: nil, remembered: nil))
+    expect(status).to eq(503)
+  end
+
+  it "treats a jar it cannot read as anonymous rather than raising" do
+    broken = env(wait: 30.0).merge('action_dispatch.cookies' => Object.new)
+    status, = middleware.call(broken)
+    expect(status).to eq(503)
   end
 end

--- a/spec/requests/anon_load_shed_spec.rb
+++ b/spec/requests/anon_load_shed_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "AnonLoadShed cookie handling" do
+  # The unit spec stubs the cookie jar, so it proves the middleware's branching
+  # but not that a real signed cookie is actually readable from where the
+  # middleware sits in the stack. That is the part most likely to break: the
+  # jar needs `action_dispatch.key_generator` and friends on the env, and if
+  # they were missing the rescue in `permanent_user_id` would swallow it and
+  # silently shed every remembered reader — exactly the bug being fixed, with
+  # green unit tests. So build the cookie the way SessionsController does and
+  # read it back through the middleware's own code path.
+  before(:each) do
+    stub_const('Rack::Timeout::ENV_INFO_KEY', 'rack-timeout.info') unless defined?(Rack::Timeout::ENV_INFO_KEY)
+  end
+
+  let(:downstream) { ->(_env) { [200, {}, ['ok']] } }
+  let(:middleware) { AnonLoadShed.new(downstream) }
+  let(:user) { create(:user) }
+
+  # Log in for real with "remember me" so the signed cookie is produced by the
+  # application rather than hand-rolled here, then keep only that cookie: a
+  # returning reader whose browser dropped the session cookie sends exactly
+  # this and nothing else.
+  def remember_me_cookie
+    post '/login', params: { username: user.username, password: 'knownpass', remember_me: '1' }
+    raw = response.headers['Set-Cookie']
+    raw = raw.join("\n") if raw.is_a?(Array)
+    entry = raw.split("\n").find { |c| c.start_with?('user_id=') }
+    expect(entry).to be_present, "expected login to set a permanent user_id cookie"
+    entry.split(';').first
+  end
+
+  def env_with(cookie:, wait:)
+    Rails.application.env_config.merge(
+      Rack::MockRequest.env_for('/posts', 'HTTP_COOKIE' => cookie),
+    ).merge(
+      Rack::Timeout::ENV_INFO_KEY => Struct.new(:wait).new(wait),
+      'rack.session'              => {},
+    )
+  end
+
+  it "passes through a remembered reader carrying only the permanent cookie" do
+    status, = middleware.call(env_with(cookie: remember_me_cookie, wait: 30.0))
+    expect(status).to eq(200)
+  end
+
+  it "sheds an otherwise identical request whose cookie signature is tampered with" do
+    tampered = remember_me_cookie.sub(/.$/) { |c| c == 'A' ? 'B' : 'A' }
+    status, = middleware.call(env_with(cookie: tampered, wait: 30.0))
+    expect(status).to eq(503)
+  end
+end


### PR DESCRIPTION
## Problem

`AnonLoadShed` selects which requests to shed. It reads `env['rack.session'][:user_id]` only. This test does not identify readers who log in with "remember me".

Those readers hold two different credentials:

- The session cookie has no expiry. The browser deletes it when the browser closes.
- The "remember me" credential is a separate permanent signed cookie.

`Authentication::Web#check_permanent_user` copies that cookie into the session. It is a `before_action` in `ApplicationController`. Therefore it runs after the middleware stack.

A remembered reader who restarts the browser sends a valid permanent cookie and an empty session. The middleware identifies this reader as anonymous. The middleware then sheds the request.

The reader cannot correct this condition by retrying. The 503 response does not reach the controller. The controller does not restore the session. The next request sheds again. This continues while the queue stays deep. Only `/login` stops the loop, because `/login` is already exempt.

## Evidence

The data below is from 2026-08-21. The site shed 12.17% of all requests on that day.

| Path | Requests | Shed | Rate |
|---|---|---|---|
| `/messages` | 10,354 | 0 | 0.00% |
| `/favorites` | 1,201 | 26 | 2.16% |

`/messages` shows that the middleware reads sessions correctly. Readers with a live session stayed protected. `/favorites` shows the remaining defect. A reader also reported this condition. That reader was logged in and received `Server busy, please try again shortly.`

## Change

1. `logged_in?` also reads the signed `user_id` cookie. The code verifies the signature. It does not test only for presence. Therefore a scraper cannot avoid the shed with an invented `user_id` cookie.
2. `call` now tests the queue wait first. Identification of the reader builds a cookie jar. The middleware builds that jar only for a request that it is otherwise about to shed. In steady state the cost stays at one env lookup.

The new order does not change any verdict. All three tests are pass-through tests.

## Tests

The unit spec uses a stub jar. A stub jar cannot show that a real signed cookie is readable from this position in the stack. That failure mode is silent, and it is identical to the defect that this change corrects.

`spec/requests/anon_load_shed_spec.rb` therefore logs in for real with `remember_me`. It keeps only the permanent cookie. It reads that cookie back through the middleware. A second example changes one character of the signature and expects a 503. The two examples together show real verification.

## Risk

`permanent_user_id` uses `rescue StandardError`. If the cookie jar fails to build in production, the middleware sheds every remembered reader and the specs stay green. This is the reason for the request spec. A New Relic custom attribute on the rescue would confirm the path in production. I suggest that as separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjDWH9Tyo14YkpXBQwKryR
