### PR TITLE
Let authors share draft and multitag status with coauthors

### DIFF
--- a/app/assets/stylesheets/replies.scss
+++ b/app/assets/stylesheets/replies.scss
@@ -124,6 +124,17 @@ div.post-subheader { width: 100%; }
   .view-button { background-color: $bg_color_navbutton; }
 }
 
+/* Coauthors' in-progress drafts and multitags */
+.post-in-progress { font-style: italic; }
+
+.still-tagging {
+  clear: both;
+  padding-top: 5px;
+  font-size: $font_size_smallish;
+
+  label { padding-left: 3px; }
+}
+
 .post-expander {
   min-height: 5px;
   background-color: $bg_color_expander;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,7 +96,10 @@ class ApplicationController < ActionController::Base
     posts_count = posts.except(:select, :order, :group).count(count_target)
     posts = posts_list_relation(posts, select: select, max: max)
     posts = posts.paginate(page: page, total_entries: posts_count) if with_pagination
-    calculate_view_status(posts, with_unread: with_unread) if logged_in?
+    if logged_in?
+      calculate_view_status(posts, with_unread: with_unread)
+      calculate_draft_statuses(posts)
+    end
     posts
   end
   helper_method :posts_from_relation
@@ -156,6 +159,44 @@ class ApplicationController < ActionController::Base
     @unread_counts = Reply.where(post_id: @unread_ids).joins('INNER JOIN post_views ON replies.post_id = post_views.post_id')
     @unread_counts = @unread_counts.where(post_views: { user_id: current_user.id })
     @unread_counts = @unread_counts.where('replies.created_at > post_views.read_at').group(:post_id).count
+  end
+
+  # In-progress statuses (a saved draft, a multitag underway) for the current user's own
+  # posts, and for coauthors who have opted into showing theirs on posts the current user
+  # writes in. Both are hashes of post id => statuses, where a status list is some
+  # combination of :draft and :tagging.
+  def calculate_draft_statuses(posts)
+    @own_draft_statuses ||= {}
+    @coauthor_draft_statuses ||= {}
+    post_ids = posts.map(&:id)
+    return if post_ids.empty?
+
+    own_authorships = Post::Author.where(user_id: current_user.id, post_id: post_ids).pluck(:post_id, :still_tagging).to_h
+    own_draft_ids = ReplyDraft.where(user_id: current_user.id, post_id: post_ids).pluck(:post_id)
+
+    (own_draft_ids | own_authorships.select { |_, tagging| tagging }.keys).each do |post_id|
+      status = []
+      status << :draft if own_draft_ids.include?(post_id)
+      status << :tagging if own_authorships[post_id]
+      @own_draft_statuses[post_id] = status
+    end
+
+    return if own_authorships.empty?
+    calculate_coauthor_draft_statuses(own_authorships.keys)
+  end
+
+  def calculate_coauthor_draft_statuses(authored_ids)
+    authors = Post::Author.showing_drafts.where(post_id: authored_ids).where.not(user_id: current_user.id).includes(:user).to_a
+    return if authors.empty?
+
+    drafts = ReplyDraft.where(post_id: authored_ids, user_id: authors.map(&:user_id)).pluck(:post_id, :user_id)
+    authors.sort_by { |author| author.user.username.downcase }.each do |author|
+      status = []
+      status << :draft if drafts.include?([author.post_id, author.user_id])
+      status << :tagging if author.still_tagging?
+      next if status.empty?
+      (@coauthor_draft_statuses[author.post_id] ||= {})[author.user] = status
+    end
   end
 
   def calculate_reply_bookmarks(replies)

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -3,6 +3,7 @@ class DraftsController < WritableController
   def create
     draft = make_draft
     redirect_to posts_path and return unless draft.post
+    update_tagging_status(draft.post)
     redirect_to post_path(draft.post, page: :unread, anchor: :unread)
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -211,6 +211,7 @@ class PostsController < WritableController
   def update
     mark_unread and return if params[:unread].present?
     mark_hidden and return if params[:hidden].present?
+    change_draft_visibility and return if params[:show_drafts].present?
 
     require_edit_permission
     return if performed?
@@ -440,6 +441,29 @@ class PostsController < WritableController
     else
       @post.unignore(current_user)
       flash[:success] = "Post has been unhidden"
+    end
+    redirect_to @post
+  end
+
+  def change_draft_visibility
+    author = @post.author_for(current_user)
+    unless author
+      flash[:error] = "You are not an author of this post."
+      return redirect_to @post
+    end
+
+    show_drafts = case params[:show_drafts]
+      when 'true' then true
+      when 'false' then false
+    end
+    author.update!(show_drafts: show_drafts)
+
+    flash[:success] = if show_drafts.nil?
+      "Your draft status on this post now uses your default setting."
+    elsif show_drafts
+      "Your draft status on this post is now visible to your coauthors."
+    else
+      "Your draft status on this post is now hidden from your coauthors."
     end
     redirect_to @post
   end

--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -347,6 +347,8 @@ class RepliesController < WritableController
       redirect_to post_path(errored_reply.post) and return
     end
 
+    update_tagging_status(first_reply.post)
+
     flash[:success] = "#{'Reply'.pluralize(@multi_replies.length)} posted."
     redirect_to reply_path(first_reply, anchor: "reply-#{first_reply.id}")
   end
@@ -378,6 +380,8 @@ class RepliesController < WritableController
       editor_setup
       render :edit
     else
+      update_tagging_status(@reply.post)
+
       flash[:success] = "Reply updated."
       redirect_to reply_path(@reply, anchor: "reply-#{@reply.id}")
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -274,6 +274,7 @@ class UsersController < ApplicationController
       :show_user_in_switcher,
       :default_hide_edit_delete_buttons,
       :default_hide_add_bookmark_button,
+      :show_drafts_to_coauthors,
     )
   end
 

--- a/app/controllers/writable_controller.rb
+++ b/app/controllers/writable_controller.rb
@@ -131,6 +131,7 @@ class WritableController < ApplicationController
         @reply.editor_mode ||= params[:editor_mode] || current_user.default_editor
         @draft = ReplyDraft.draft_for(@post.id, current_user.id)
       end
+      @in_progress_statuses = @post.in_progress_statuses_for(current_user)
 
       @post.mark_read(current_user, at_time: @post.read_time_for(@replies)) unless @permalink_jumped_ahead
     end
@@ -211,6 +212,15 @@ class WritableController < ApplicationController
       end
     end
     draft
+  end
+
+  # records whether the user has more replies coming on this post, from the reply form's
+  # "still tagging" check box (only rendered when their draft status is shared)
+  def update_tagging_status(post)
+    return unless post
+    return unless params.key?(:still_tagging)
+    return unless (author = post.author_for(current_user))
+    author.update(still_tagging: params[:still_tagging] == '1')
   end
 
   def process_npc(writable, permitted_character_params)

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -23,6 +23,38 @@ module PostHelper
     safe_join([first_link, others], ' and ')
   end
 
+  DRAFT_STATUS_PHRASES = { draft: 'draft in progress', tagging: 'still tagging' }
+
+  # icons summarising who has something in progress on a post, shown in post lists
+  def draft_status_icons(post)
+    own = @own_draft_statuses.try(:[], post.id)
+    coauthors = @coauthor_draft_statuses.try(:[], post.id)
+    return if own.blank? && coauthors.blank?
+
+    icons = []
+    if own.present?
+      title = "You: #{draft_status_phrase(own)}"
+      icons << image_tag('icons/pencil.png', class: 'vmid', title: title, alt: title)
+    end
+    if coauthors.present?
+      title = coauthors.map { |user, status| "#{user.username}: #{draft_status_phrase(status)}" }.join(', ')
+      icons << image_tag('icons/status_online.png', class: 'vmid', title: title, alt: title)
+    end
+    safe_join(icons)
+  end
+
+  def draft_status_phrase(status)
+    status.map { |key| DRAFT_STATUS_PHRASES[key] }.to_sentence
+  end
+
+  # "Alicorn has a draft in progress and is still tagging"
+  def draft_status_sentence(user, status)
+    phrases = []
+    phrases << 'has a draft in progress' if status.include?(:draft)
+    phrases << 'is still tagging' if status.include?(:tagging)
+    "#{user.username} #{phrases.to_sentence}"
+  end
+
   def allowed_boards(obj, user)
     authored_ids = BoardAuthor.where(user: user).select(:board_id)
     Board.where(id: obj.board_id).or(Board.where(authors_locked: false)).or(Board.where(id: authored_ids)).ordered

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -243,6 +243,25 @@ class Post < ApplicationRecord
     author_ids.include?(user.id)
   end
 
+  # In-progress statuses of this post's other authors, for those who have opted into
+  # showing them. Returns a hash of User => array of :draft / :tagging, only including
+  # authors who currently have something in progress.
+  def in_progress_statuses_for(user)
+    return {} unless user
+    return {} unless author_for(user)
+
+    authors = post_authors.showing_drafts.where.not(user_id: user.id).includes(:user).to_a
+    return {} if authors.empty?
+
+    draft_user_ids = reply_drafts.where(user_id: authors.map(&:user_id)).pluck(:user_id)
+    authors.sort_by { |author| author.user.username.downcase }.each_with_object({}) do |author, statuses|
+      status = []
+      status << :draft if draft_user_ids.include?(author.user_id)
+      status << :tagging if author.still_tagging?
+      statuses[author.user] = status if status.present?
+    end
+  end
+
   def taggable_by?(user)
     return false unless user
     return false if complete? || abandoned?

--- a/app/models/post/author.rb
+++ b/app/models/post/author.rb
@@ -7,6 +7,19 @@ class Post::Author < ApplicationRecord
 
   after_commit :invalidate_caches, on: [:create, :destroy]
 
+  # authors whose in-progress statuses are visible to their coauthors, either
+  # because of a per-post override or because of their site-wide default
+  scope :showing_drafts, -> {
+    joins(:user).where('post_authors.show_drafts IS TRUE OR (post_authors.show_drafts IS NULL AND users.show_drafts_to_coauthors IS TRUE)')
+  }
+
+  # nil show_drafts means the author has not set a preference for this post, so
+  # their site-wide default applies
+  def shows_drafts?
+    return show_drafts unless show_drafts.nil?
+    !!user.show_drafts_to_coauthors
+  end
+
   def invalidate_caches
     self.class.clear_cache_for(user)
   end

--- a/app/views/posts/_list_item.haml
+++ b/app/views/posts/_list_item.haml
@@ -21,6 +21,7 @@
       - elsif @show_unread
         = link_to unread_path(post) do
           = image_tag lastlink_img, class: 'vmid mobile-target', title: 'First Unread', alt: 'Jump To End'
+      = draft_status_icons(post)
     - if logged_in? && @opened_ids.present? && @opened_ids.exclude?(post.id)
       %b= link_to post.subject, post_path(post), title: strip_tags(post.description)
     - else

--- a/app/views/posts/show.haml
+++ b/app/views/posts/show.haml
@@ -111,6 +111,22 @@
           %div
             = image_tag "icons/star_add.png".freeze, class: 'vmid'.freeze, style: 'margin-bottom: 3px;'.freeze, alt: ''
             Favorite
+      - if (draft_author = @post.author_for(current_user))
+        - if draft_author.shows_drafts?
+          = link_to post_path(@post, show_drafts: 'false'.freeze), method: :put do
+            %div
+              = image_tag "icons/status_online.png".freeze, alt: ''
+              Hide Draft Status Here
+        - else
+          = link_to post_path(@post, show_drafts: 'true'.freeze), method: :put do
+            %div
+              = image_tag "icons/status_online.png".freeze, alt: ''
+              Show Draft Status Here
+        - unless draft_author.show_drafts.nil?
+          = link_to post_path(@post, show_drafts: 'default'.freeze), method: :put do
+            %div
+              = image_tag "icons/swap.png".freeze, alt: ''
+              Use Default Draft Status
       - if @post.metadata_editable_by?(current_user)
         - unless @post.complete?
           = link_to post_path(@post, status: 'complete'.freeze), method: :put do
@@ -210,6 +226,10 @@
   = render 'posts/paginator', paginated: @replies
 - if logged_in? && @unread.nil?
   %a.noheight{id: "unread"}= " "
+- if @in_progress_statuses.present?
+  .post-subheader.post-in-progress
+    = image_tag "icons/status_online.png".freeze, class: 'vmid'.freeze, alt: ''
+    = @in_progress_statuses.map { |author, status| draft_status_sentence(author, status) }.join('; ')
 - if @post.taggable_by?(current_user) && !split_ui
   - post_open = !@post.authors_locked?
   - draft_exists = !@reply.content.nil?

--- a/app/views/replies/_write.haml
+++ b/app/views/replies/_write.haml
@@ -43,6 +43,12 @@
       = submit_tag "Add More Replies", class: 'button', id: 'add_more_button', name: 'button_add_more', data: { disable_with: 'Adding...' }
       - if multi_replies_params.present?
         = submit_tag "Discard Replies", class: 'button', id: 'discard_multi_reply_button', name: 'button_discard_multi_reply', data: { disable_with: 'Discarding...', confirm: "Discard all replies added?" }
+      - if (tagging_author = reply.post.try(:author_for, current_user))&.shows_drafts?
+        .still-tagging
+          = hidden_field_tag :still_tagging, '0'.freeze, id: nil
+          - still_tagging = params.key?(:still_tagging) ? params[:still_tagging] == '1'.freeze : tagging_author.still_tagging?
+          = check_box_tag :still_tagging, '1'.freeze, still_tagging
+          = label_tag :still_tagging, 'Show my coauthors that I have more replies coming'
     - if reply.post.author_for(current_user).present?
       %hr.clear
       .post-note-editor

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -93,6 +93,11 @@
         = f.check_box :show_user_in_switcher
         = f.label :show_user_in_switcher, "Show user character"
     %div
+      .sub Draft status
+      .checkbox-field{class: cycle('even', 'odd')}
+        = f.check_box :show_drafts_to_coauthors
+        = f.label :show_drafts_to_coauthors, "Show coauthors when I have a draft or multitag in progress"
+    %div
       .sub Reply defaults
       .checkbox-fields{class: cycle('even', 'odd')}
         - unless current_user.read_only?

--- a/db/migrate/20260825120000_add_draft_status_visibility.rb
+++ b/db/migrate/20260825120000_add_draft_status_visibility.rb
@@ -1,0 +1,14 @@
+class AddDraftStatusVisibility < ActiveRecord::Migration[8.0]
+  def change
+    # global default: whether a user's in-progress statuses are shown to their coauthors
+    add_column :users, :show_drafts_to_coauthors, :boolean, default: false
+
+    change_table :post_authors, bulk: true do |t|
+      # per-thread override of the above; nil means "use the user's default"
+      t.boolean :show_drafts
+
+      # set by an author to say they intend to keep tagging (a multitag in progress)
+      t.boolean :still_tagging, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_25_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -314,6 +314,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.boolean "joined", default: false
     t.datetime "joined_at", precision: nil
     t.text "private_note"
+    t.boolean "show_drafts"
+    t.boolean "still_tagging", default: false
     t.index ["post_id"], name: "index_post_authors_on_post_id"
     t.index ["user_id"], name: "index_post_authors_on_user_id"
   end
@@ -504,6 +506,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_04_000000) do
     t.boolean "default_hide_edit_delete_buttons", default: false
     t.boolean "default_hide_add_bookmark_button", default: false
     t.boolean "moiety_colors_unread", default: false
+    t.boolean "show_drafts_to_coauthors", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/spec/controllers/posts/owed_spec.rb
+++ b/spec/controllers/posts/owed_spec.rb
@@ -46,6 +46,45 @@ RSpec.describe PostsController, 'GET owed' do
     end
   end
 
+  context "with draft statuses" do
+    render_views
+
+    let(:coauthor) { create(:user, username: 'Alicorn', show_drafts_to_coauthors: true) }
+    let(:shared_post) { create(:post, user: user, unjoined_authors: [coauthor]) }
+
+    before(:each) do
+      login_as(user)
+      create(:reply, post: shared_post, user: coauthor)
+      shared_post.mark_read(user)
+    end
+
+    it "shows your own draft" do
+      create(:reply_draft, post: shared_post, user: user)
+
+      get :owed
+      expect(assigns(:own_draft_statuses)).to eq({ shared_post.id => [:draft] })
+      expect(response.body).to include('You: draft in progress')
+    end
+
+    it "shows a coauthor's draft and multitag" do
+      create(:reply_draft, post: shared_post, user: coauthor)
+      shared_post.author_for(coauthor).update!(still_tagging: true)
+
+      get :owed
+      expect(assigns(:coauthor_draft_statuses)).to eq({ shared_post.id => { coauthor => [:draft, :tagging] } })
+      expect(response.body).to include('Alicorn: draft in progress and still tagging')
+    end
+
+    it "hides a coauthor's draft when they have not opted in" do
+      coauthor.update!(show_drafts_to_coauthors: false)
+      create(:reply_draft, post: shared_post, user: coauthor)
+
+      get :owed
+      expect(assigns(:coauthor_draft_statuses)).to eq({})
+      expect(response.body).not_to include('draft in progress')
+    end
+  end
+
   context "with hidden" do
     let(:hidden_post) { create(:post, user: user) }
 

--- a/spec/controllers/posts/show_spec.rb
+++ b/spec/controllers/posts/show_spec.rb
@@ -186,6 +186,55 @@ RSpec.describe PostsController, 'GET show' do
     end
   end
 
+  context "with in-progress coauthors" do
+    render_views
+
+    let(:author) { create(:user) }
+    let(:coauthor) { create(:user, username: 'Alicorn') }
+    let(:shared_post) { create(:post, user: author, unjoined_authors: [coauthor]) }
+
+    before(:each) { login_as(author) }
+
+    it "shows a coauthor's draft when they share it" do
+      coauthor.update!(show_drafts_to_coauthors: true)
+      create(:reply_draft, post: shared_post, user: coauthor)
+
+      get :show, params: { id: shared_post.id }
+
+      expect(assigns(:in_progress_statuses)).to eq({ coauthor => [:draft] })
+      expect(response.body).to include('Alicorn has a draft in progress')
+    end
+
+    it "shows a coauthor's multitag when they share it on this post" do
+      shared_post.author_for(coauthor).update!(show_drafts: true, still_tagging: true)
+
+      get :show, params: { id: shared_post.id }
+
+      expect(assigns(:in_progress_statuses)).to eq({ coauthor => [:tagging] })
+      expect(response.body).to include('Alicorn is still tagging')
+    end
+
+    it "hides a coauthor's draft by default" do
+      create(:reply_draft, post: shared_post, user: coauthor)
+
+      get :show, params: { id: shared_post.id }
+
+      expect(assigns(:in_progress_statuses)).to eq({})
+      expect(response.body).not_to include('draft in progress')
+    end
+
+    it "does not show anything to non-authors" do
+      coauthor.update!(show_drafts_to_coauthors: true)
+      create(:reply_draft, post: shared_post, user: coauthor)
+      login_as(create(:user))
+
+      get :show, params: { id: shared_post.id }
+
+      expect(assigns(:in_progress_statuses)).to eq({})
+      expect(response.body).not_to include('draft in progress')
+    end
+  end
+
   context "with at_id" do
     let(:post) { create(:post) }
     let(:second_last_reply) { post.replies.ordered.last(2).first }

--- a/spec/controllers/posts/update_spec.rb
+++ b/spec/controllers/posts/update_spec.rb
@@ -397,6 +397,57 @@ RSpec.describe PostsController, 'PUT update' do
     end
   end
 
+  context "draft status visibility" do
+    let(:draft_post) { create(:post, user: user, unjoined_authors: [coauthor]) }
+
+    before(:each) { login_as(user) }
+
+    it "requires authorship of the post" do
+      login_as(create(:user))
+
+      put :update, params: { id: draft_post.id, show_drafts: 'true' }
+
+      expect(response).to redirect_to(post_url(draft_post))
+      expect(flash[:error]).to eq("You are not an author of this post.")
+      expect(draft_post.author_for(user).show_drafts).to be_nil
+    end
+
+    it "shows draft status to coauthors" do
+      put :update, params: { id: draft_post.id, show_drafts: 'true' }
+
+      expect(response).to redirect_to(post_url(draft_post))
+      expect(flash[:success]).to eq("Your draft status on this post is now visible to your coauthors.")
+      expect(draft_post.author_for(user).show_drafts).to eq(true)
+    end
+
+    it "hides draft status from coauthors" do
+      user.update!(show_drafts_to_coauthors: true)
+
+      put :update, params: { id: draft_post.id, show_drafts: 'false' }
+
+      expect(response).to redirect_to(post_url(draft_post))
+      expect(flash[:success]).to eq("Your draft status on this post is now hidden from your coauthors.")
+      expect(draft_post.author_for(user).show_drafts).to eq(false)
+      expect(draft_post.author_for(user).shows_drafts?).to eq(false)
+    end
+
+    it "reverts to the user's default" do
+      draft_post.author_for(user).update!(show_drafts: false)
+
+      put :update, params: { id: draft_post.id, show_drafts: 'default' }
+
+      expect(response).to redirect_to(post_url(draft_post))
+      expect(flash[:success]).to eq("Your draft status on this post now uses your default setting.")
+      expect(draft_post.author_for(user).show_drafts).to be_nil
+    end
+
+    it "only changes the current user's setting" do
+      put :update, params: { id: draft_post.id, show_drafts: 'true' }
+
+      expect(draft_post.author_for(coauthor).show_drafts).to be_nil
+    end
+  end
+
   context "preview" do
     before(:each) { login_as(user) }
 

--- a/spec/controllers/replies/create_spec.rb
+++ b/spec/controllers/replies/create_spec.rb
@@ -284,6 +284,37 @@ RSpec.describe RepliesController, 'POST create' do
     expect(reply.character_alias_id).to eq(calias.id)
   end
 
+  context "with the still tagging check box" do
+    let(:user) { create(:user) }
+    let(:reply_post) { create(:post, user: user) }
+
+    before(:each) do
+      login_as(user)
+      reply_post.mark_read(user, at_time: reply_post.created_at + 1.second, force: true)
+    end
+
+    def create_reply(params={})
+      post :create, params: { reply: { post_id: reply_post.id, content: 'test!' } }.merge(params)
+    end
+
+    it "marks the author as still tagging when checked" do
+      create_reply(still_tagging: '1')
+      expect(reply_post.author_for(user).still_tagging).to eq(true)
+    end
+
+    it "clears the flag when unchecked" do
+      reply_post.author_for(user).update!(still_tagging: true)
+      create_reply(still_tagging: '0')
+      expect(reply_post.author_for(user).still_tagging).to eq(false)
+    end
+
+    it "leaves the flag alone when the check box is absent" do
+      reply_post.author_for(user).update!(still_tagging: true)
+      create_reply
+      expect(reply_post.author_for(user).still_tagging).to eq(true)
+    end
+  end
+
   it "allows you to reply to a post you created" do
     user = create(:user)
     login_as(user)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -403,6 +403,7 @@ RSpec.describe UsersController do
         favorite_notifications: false,
         show_user_in_switcher: false,
         default_character_split: 'none',
+        show_drafts_to_coauthors: true,
       }
 
       # ensure new values are different, so test tests correct things

--- a/spec/helpers/post_helper_spec.rb
+++ b/spec/helpers/post_helper_spec.rb
@@ -228,4 +228,62 @@ RSpec.describe PostHelper do
 
     it_behaves_like 'unread_or_opened'
   end
+
+  describe "#draft_status_sentence" do
+    let(:user) { create(:user, username: 'Alicorn') }
+
+    it "describes a draft" do
+      expect(helper.draft_status_sentence(user, [:draft])).to eq('Alicorn has a draft in progress')
+    end
+
+    it "describes a multitag" do
+      expect(helper.draft_status_sentence(user, [:tagging])).to eq('Alicorn is still tagging')
+    end
+
+    it "describes both" do
+      expect(helper.draft_status_sentence(user, [:draft, :tagging])).to eq('Alicorn has a draft in progress and is still tagging')
+    end
+  end
+
+  describe "#draft_status_icons" do
+    let(:post) { create(:post) }
+    let(:coauthor) { create(:user, username: 'Alicorn') }
+
+    before(:each) do
+      assign(:own_draft_statuses, own)
+      assign(:coauthor_draft_statuses, coauthors)
+    end
+
+    context "with nothing in progress" do
+      let(:own) { {} }
+      let(:coauthors) { {} }
+
+      it "renders nothing" do
+        expect(helper.draft_status_icons(post)).to be_nil
+      end
+    end
+
+    context "with your own draft" do
+      let(:own) { { post.id => [:draft] } }
+      let(:coauthors) { {} }
+
+      it "renders one icon" do
+        icons = helper.draft_status_icons(post)
+        expect(icons).to include('You: draft in progress')
+        expect(icons.scan('<img').size).to eq(1)
+      end
+    end
+
+    context "with both yours and a coauthor's" do
+      let(:own) { { post.id => [:draft, :tagging] } }
+      let(:coauthors) { { post.id => { coauthor => [:tagging] } } }
+
+      it "renders both icons" do
+        icons = helper.draft_status_icons(post)
+        expect(icons).to include('You: draft in progress and still tagging')
+        expect(icons).to include('Alicorn: still tagging')
+        expect(icons.scan('<img').size).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/models/post/author_spec.rb
+++ b/spec/models/post/author_spec.rb
@@ -54,4 +54,40 @@ RSpec.describe Post::Author do
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  describe "#shows_drafts?" do
+    let(:user) { create(:user) }
+    let(:post_author) { create(:post_author, user: user) }
+
+    it "defaults to the user's site-wide setting" do
+      expect(post_author.shows_drafts?).to eq(false)
+      user.update!(show_drafts_to_coauthors: true)
+      expect(post_author.reload.shows_drafts?).to eq(true)
+    end
+
+    it "is overridden per post" do
+      post_author.update!(show_drafts: true)
+      expect(post_author.shows_drafts?).to eq(true)
+
+      user.update!(show_drafts_to_coauthors: true)
+      post_author.update!(show_drafts: false)
+      expect(post_author.reload.shows_drafts?).to eq(false)
+    end
+  end
+
+  describe ".showing_drafts" do
+    it "finds authors sharing by default or by override, and no others" do
+      sharing_user = create(:user, show_drafts_to_coauthors: true)
+      private_user = create(:user)
+
+      by_default = create(:post_author, user: sharing_user)
+      by_override = create(:post_author, user: private_user, show_drafts: true)
+      opted_out = create(:post_author, user: sharing_user, show_drafts: false)
+      private_author = create(:post_author, user: private_user)
+
+      results = Post::Author.showing_drafts
+      expect(results).to include(by_default, by_override)
+      expect(results).not_to include(opted_out, private_author)
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1049,6 +1049,56 @@ RSpec.describe Post do
     end
   end
 
+  describe "#in_progress_statuses_for" do
+    let(:poster) { create(:user) }
+    let(:coauthor) { create(:user, show_drafts_to_coauthors: true) }
+    let(:post) { create(:post, user: poster, unjoined_authors: [coauthor]) }
+
+    it "is empty without a user" do
+      expect(post.in_progress_statuses_for(nil)).to eq({})
+    end
+
+    it "is empty for non-authors" do
+      create(:reply_draft, post: post, user: coauthor)
+      expect(post.in_progress_statuses_for(create(:user))).to eq({})
+    end
+
+    it "reports a coauthor's draft" do
+      create(:reply_draft, post: post, user: coauthor)
+      expect(post.in_progress_statuses_for(poster)).to eq({ coauthor => [:draft] })
+    end
+
+    it "reports a coauthor's multitag" do
+      post.author_for(coauthor).update!(still_tagging: true)
+      expect(post.in_progress_statuses_for(poster)).to eq({ coauthor => [:tagging] })
+    end
+
+    it "reports both at once" do
+      create(:reply_draft, post: post, user: coauthor)
+      post.author_for(coauthor).update!(still_tagging: true)
+      expect(post.in_progress_statuses_for(poster)).to eq({ coauthor => [:draft, :tagging] })
+    end
+
+    it "hides the status of authors who have not opted in" do
+      private_author = create(:user)
+      post.author_for(coauthor).update!(show_drafts: false)
+      Post::Author.create!(post: post, user: private_author)
+      create(:reply_draft, post: post, user: coauthor)
+      create(:reply_draft, post: post, user: private_author)
+      expect(post.in_progress_statuses_for(poster)).to eq({})
+    end
+
+    it "does not report your own status back to you" do
+      create(:reply_draft, post: post, user: coauthor)
+      expect(post.in_progress_statuses_for(coauthor)).to eq({})
+    end
+
+    it "ignores drafts on other posts" do
+      create(:reply_draft, post: create(:post), user: coauthor)
+      expect(post.in_progress_statuses_for(poster)).to eq({})
+    end
+  end
+
   describe "#visible_to" do
     it "logged out only shows public posts" do
       create(:post, privacy: :private)

--- a/spec/system/posts/show_spec.rb
+++ b/spec/system/posts/show_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe "Viewing posts" do
 
     login(user)
     visit post_path(shared_post)
+    expect(page).to have_selector('#post-title', text: shared_post.subject)
     expect(page).to have_no_text('Alicorn has a draft in progress')
 
     coauthor.update!(show_drafts_to_coauthors: true)
@@ -226,6 +227,7 @@ RSpec.describe "Viewing posts" do
     # the coauthor can opt back out for this thread specifically
     shared_post.author_for(coauthor).update!(show_drafts: false)
     visit post_path(shared_post)
+    expect(page).to have_selector('#post-title', text: shared_post.subject)
     expect(page).to have_no_text('Alicorn has a draft in progress')
   end
 
@@ -234,6 +236,7 @@ RSpec.describe "Viewing posts" do
 
     login(user)
     visit post_path(shared_post)
+    expect(page).to have_selector('#post-title', text: shared_post.subject)
     expect(page).to have_no_field('still_tagging')
     expect(page).to have_no_link("Use Default Draft Status")
 

--- a/spec/system/posts/show_spec.rb
+++ b/spec/system/posts/show_spec.rb
@@ -210,6 +210,44 @@ RSpec.describe "Viewing posts" do
     expect(page).to have_selector(".post-content", count: 3)
   end
 
+  scenario "Sharing draft status with coauthors" do
+    coauthor = create(:user, username: 'Alicorn')
+    shared_post = create(:post, user: user, unjoined_authors: [coauthor])
+    create(:reply_draft, post: shared_post, user: coauthor)
+
+    login(user)
+    visit post_path(shared_post)
+    expect(page).to have_no_text('Alicorn has a draft in progress')
+
+    coauthor.update!(show_drafts_to_coauthors: true)
+    visit post_path(shared_post)
+    expect(page).to have_text('Alicorn has a draft in progress')
+
+    # the coauthor can opt back out for this thread specifically
+    shared_post.author_for(coauthor).update!(show_drafts: false)
+    visit post_path(shared_post)
+    expect(page).to have_no_text('Alicorn has a draft in progress')
+  end
+
+  scenario "Toggling your own draft status on a thread" do
+    shared_post = create(:post, user: user, unjoined_authors: [create(:user)])
+
+    login(user)
+    visit post_path(shared_post)
+    expect(page).to have_no_field('still_tagging')
+    expect(page).to have_no_link("Use Default Draft Status")
+
+    within('#post-menu-box') { click_link "Show Draft Status Here" }
+    expect(page).to have_text("Your draft status on this post is now visible to your coauthors.")
+    expect(shared_post.author_for(user).show_drafts).to eq(true)
+    expect(page).to have_field('still_tagging', checked: false)
+
+    within('#post-menu-box') { click_link "Use Default Draft Status" }
+    expect(page).to have_text("Your draft status on this post now uses your default setting.")
+    expect(shared_post.author_for(user).show_drafts).to be_nil
+    expect(page).to have_no_field('still_tagging')
+  end
+
   scenario "Hidden reply buttons" do
     login(user)
     create_list(:reply, 3, post: post)


### PR DESCRIPTION
A saved draft or a multitag in progress currently looks identical to nothing happening, even though the two call for different responses from a coauthor. This adds an opt-in way to share that state.

Visibility is resolved per thread: each post author row carries a nullable show_drafts override, falling back to the new show_drafts_to_coauthors setting on the user. Both default to private, so nothing is shared until someone opts in, and the per-thread toggle in the post menu can also revert to the user's default.

Two things are shared once enabled:
- a saved reply draft, detected from reply_drafts
- a multitag, from a "more replies coming" check box on the reply form, which is only rendered when the author is sharing status on that thread and is cleared by the next reply that leaves it unchecked

Coauthors see a summary line above the reply form on the post page, and post lists (Replies Owed included) gain icons for your own in-progress threads and for coauthors who share theirs.


Claude-Session: https://claude.ai/code/session_01QP8nsJdmkC2tcAzTUpZftn