### PR TITLE
Tell throttled and banned clients how long to wait

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,66 @@
 # frozen_string_literal: true
+
+# The responses this app sends when a client is asking for too much.
+#
+# Crawlers read these as instructions, and the codes are not interchangeable.
+# Google reduces its crawl rate on 429 and 503 and backs off on Retry-After;
+# 403 and 404 mean the URL is gone for good, so answering a rate limit with
+# one is how a site gets dropped from an index rather than merely slowed
+# down. Bing reduces its rate on 429 but ignores Retry-After entirely, which
+# is why bingbot also gets a Crawl-delay in public/robots.txt.
+#
+# Defined above the production guard below so they can be exercised in specs;
+# only the wiring into Rack::Attack is production-only.
+module RackAttackResponders
+  ALLOW2BAN_NAME = 'allow2ban bots'
+
+  # The two allow2ban bans further down. Retry-After on a ban advertises the
+  # shorter of them: a client that comes back too early just gets the header
+  # again, which is the loop backing off is supposed to take.
+  SHORT_BAN = 1.hour
+  LONG_BAN = 1.day
+
+  # rack-attack's `throttled_response_retry_after_header` setting is read only
+  # inside its DEFAULT_THROTTLED_RESPONDER, so it silently stops doing
+  # anything the moment a custom responder is assigned — as one is here.
+  # Retry-After has to be set by hand, or not one 429 this app sends carries
+  # the single header that tells a client how long to wait.
+  THROTTLED = lambda do |req|
+    match_data = req.env['rack.attack.match_data']
+    now = match_data[:epoch_time]
+    retry_after = match_data[:period] - (now % match_data[:period])
+
+    headers = { 'content-type' => 'text/plain', 'retry-after' => retry_after.to_s }
+
+    # RateLimit-* describes a quota, which only means something to a client
+    # that knows it has one: our own safelisted callers and the documented
+    # API. Retry-After above is the part every other client understands.
+    if $safe_ips.include?(req.ip) || req.path.starts_with?('/api')
+      headers['ratelimit-limit'] = match_data[:limit].to_s
+      headers['ratelimit-remaining'] = '0'
+      headers['ratelimit-reset'] = (now + retry_after).to_s
+    end
+
+    [429, headers, ["Throttled\n"]]
+  end
+
+  # A ban earned by request rate is temporary and the client should be told
+  # when to return; an IP on the explicit RACK_ATTACK_BAD_IP list is not
+  # welcome at all, and 403 says exactly that.
+  #
+  # Answering the rate-earned ban with 403 was measurably counterproductive:
+  # in the seven days to 2026-09-09 ClaudeBot took 625,122 of them and never
+  # backed off, because 403 carries no notion of trying again later.
+  #
+  # rack-attack records the matched rule's name here, and `blocklist_ip`
+  # builds an anonymous blocklist, so the manual list leaves it nil.
+  BLOCKLISTED = lambda do |req|
+    return [403, { 'content-type' => 'text/plain' }, ["Forbidden\n"]] unless req.env['rack.attack.matched'] == ALLOW2BAN_NAME
+
+    [429, { 'content-type' => 'text/plain', 'retry-after' => SHORT_BAN.to_i.to_s }, ["Throttled\n"]]
+  end
+end
+
 $safe_ips = [] and return unless Rails.env.production?
 
 # allow all IPs in RACK_ATTACK_SAFE_IP split by comma
@@ -57,40 +119,29 @@ Rack::Attack.throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
   req.ip if req.path == '/login' && req.post?
 end
 
-# Return to user how many seconds to wait until they can start sending requests again
-Rack::Attack.throttled_response_retry_after_header = true
-
-# Includes conventional RateLimit-* headers for safe IPs and the API:
-Rack::Attack.throttled_responder = lambda do |req|
-  return [429, {}, ["Throttled\n"]] unless $safe_ips.include?(req.ip) || req.path.starts_with?('/api')
-
-  match_data = req.env['rack.attack.match_data']
-  now = match_data[:epoch_time]
-
-  headers = {
-    'RateLimit-Limit'     => match_data[:limit].to_s,
-    'RateLimit-Remaining' => '0',
-    'RateLimit-Reset'     => (now + match_data[:period] - (now % match_data[:period])).to_s,
-  }
-
-  [429, headers, ["Throttled\n"]]
-end
+# Tell every throttled and banned client how long to wait. See the responders
+# at the top of this file for why Retry-After cannot be left to rack-attack's
+# own setting, and why a rate-earned ban answers 429 rather than 403.
+Rack::Attack.throttled_responder = RackAttackResponders::THROTTLED
+Rack::Attack.blocklisted_responder = RackAttackResponders::BLOCKLISTED
 
 def req_logged_in?(req)
   req.session[:user_id].present?
 end
 
 # Lockout IP addresses that are hammering the app.
-Rack::Attack.blocklist('allow2ban bots') do |req|
+Rack::Attack.blocklist(RackAttackResponders::ALLOW2BAN_NAME) do |req|
   next false if req_logged_in?(req)
 
+  minute_limit = ENV.fetch("RACK_ATTACK_IP_LIMIT", 25).to_i
+
   # ban anyone at 5x the rate of our throttle limit per minute unless logged in or using API
-  Rack::Attack::Allow2Ban.filter("minute:#{req.ip}", maxretry: ENV.fetch("RACK_ATTACK_IP_LIMIT", 25).to_i, findtime: 1.minute, bantime: 1.hour) do
+  Rack::Attack::Allow2Ban.filter("minute:#{req.ip}", maxretry: minute_limit, findtime: 1.minute, bantime: RackAttackResponders::SHORT_BAN) do
     !req.path.starts_with?('/api')
   end
 
   # ban anyone at our throttle limit for the duration of an hour unless logged in or using API
-  Rack::Attack::Allow2Ban.filter("hour:#{req.ip}", maxretry: ENV.fetch("RACK_ATTACK_IP_LIMIT", 25).to_i * 60, findtime: 1.hour, bantime: 1.day) do
+  Rack::Attack::Allow2Ban.filter("hour:#{req.ip}", maxretry: minute_limit * 60, findtime: 1.hour, bantime: RackAttackResponders::LONG_BAN) do
     !req.path.starts_with?('/api')
   end
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,6 +3,11 @@
 User-agent: BLEXBot
 Crawl-delay: 30
 
+# Bingbot slows down on a 429 but ignores Retry-After, so the pace it is
+# asked to keep has to be stated here rather than in the response headers.
+User-agent: bingbot
+Crawl-delay: 10
+
 User-agent: GPTBot
 Disallow: /
 

--- a/spec/initializers/rack_attack_responders_spec.rb
+++ b/spec/initializers/rack_attack_responders_spec.rb
@@ -1,0 +1,117 @@
+RSpec.describe RackAttackResponders do
+  # rack-attack is a production-only gem, and `Rack::Attack::Request` is an
+  # empty subclass of `Rack::Request`. The responders only ever call `env`,
+  # `ip` and `path`, all of which come from `Rack::Request`, so fall back to it
+  # where the gem isn't bundled. Where it IS present the real class is used,
+  # guarding against that relationship drifting.
+  def request_class
+    defined?(Rack::Attack::Request) ? Rack::Attack::Request : Rack::Request
+  end
+
+  # rack-attack hands the responder a request and reads what it needs out of
+  # the Rack env, so a bare env is the whole contract.
+  def request(path: '/posts', client_ip: '203.0.113.1', matched: nil, limit: 25, period: 300, epoch_time: 1_757_000_000)
+    env = {
+      'PATH_INFO'              => path,
+      'REMOTE_ADDR'            => client_ip,
+      'rack.attack.matched'    => matched,
+      'rack.attack.match_data' => { limit: limit, period: period, epoch_time: epoch_time },
+    }
+    request_class.new(env)
+  end
+
+  before(:each) { $safe_ips = [] }
+
+  # Retry-After is the one header a client of any kind acts on, and it is the
+  # header rack-attack quietly stops sending as soon as a custom responder is
+  # assigned. Every 429 has to carry it.
+  describe "throttled" do
+    it "tells the client how long to wait" do
+      _status, headers, _body = described_class::THROTTLED.call(request)
+      expect(headers['retry-after']).to be_present
+    end
+
+    it "answers 429 rather than a code that reads as permanent" do
+      status, = described_class::THROTTLED.call(request)
+      expect(status).to eq(429)
+    end
+
+    # The wait is the remainder of the current throttle window, so a client
+    # that obeys it returns exactly when its quota resets rather than sooner.
+    # 1_757_000_220 sits 120s into a 300s window, leaving 180s to wait.
+    it "waits out the rest of the window, not a fixed guess" do
+      _status, headers, = described_class::THROTTLED.call(request(period: 300, epoch_time: 1_757_000_220))
+      expect(headers['retry-after']).to eq('180')
+    end
+
+    it "sends Retry-After to anonymous clients, who are the ones being throttled" do
+      _status, headers, = described_class::THROTTLED.call(request(client_ip: '198.51.100.9'))
+      expect(headers['retry-after']).to be_present
+      expect(headers).not_to have_key('ratelimit-limit')
+    end
+
+    # RateLimit-* describes a quota, which only means something to a caller
+    # that knows it has one.
+    it "adds quota headers for safelisted callers" do
+      $safe_ips = ['203.0.113.1']
+      _status, headers, = described_class::THROTTLED.call(request(client_ip: '203.0.113.1'))
+      expect(headers).to include('ratelimit-limit' => '25', 'ratelimit-remaining' => '0')
+    end
+
+    it "adds quota headers for the documented API" do
+      _status, headers, = described_class::THROTTLED.call(request(path: '/api/v1/characters'))
+      expect(headers['ratelimit-limit']).to eq('25')
+    end
+
+    it "resets the quota when the wait expires" do
+      _status, headers, = described_class::THROTTLED.call(request(path: '/api/v1/characters', period: 300, epoch_time: 1_757_000_220))
+      expect(headers['ratelimit-reset'].to_i - 1_757_000_220).to eq(180)
+    end
+  end
+
+  # A ban earned by request rate is temporary. Answering it with 403 tells a
+  # crawler the URL is gone for good, which is both wrong and, as ClaudeBot's
+  # 625,122 unbacked-off 403s showed, useless at slowing anything down.
+  describe "blocklisted" do
+    it "answers a rate-earned ban with 429 and a wait" do
+      status, headers, _body = described_class::BLOCKLISTED.call(request(matched: described_class::ALLOW2BAN_NAME))
+      expect(status).to eq(429)
+      expect(headers['retry-after']).to eq(described_class::SHORT_BAN.to_i.to_s)
+    end
+
+    # `blocklist_ip` builds an anonymous blocklist, so a manually banned IP
+    # arrives with no matched name. That one is a deliberate denial, and 403
+    # states it accurately.
+    it "still answers the manual bad-IP list with 403" do
+      status, headers, _body = described_class::BLOCKLISTED.call(request(matched: nil))
+      expect(status).to eq(403)
+      expect(headers).not_to have_key('retry-after')
+    end
+
+    it "does not treat some other named blocklist as a rate ban" do
+      status, = described_class::BLOCKLISTED.call(request(matched: 'something else'))
+      expect(status).to eq(403)
+    end
+
+    # The advertised wait has to track the ban actually applied, or the client
+    # is told to come back while still banned and simply burns the request.
+    it "advertises a wait no longer than the ban it describes" do
+      expect(described_class::SHORT_BAN).to be <= described_class::LONG_BAN
+    end
+  end
+
+  # Rack 3 specifies lowercase header names, and the middleware wrapping these
+  # responses looks them up that way.
+  it "names every header the way Rack 3 and the surrounding middleware read them" do
+    $safe_ips = ['203.0.113.1']
+    responses = [
+      described_class::THROTTLED.call(request(client_ip: '203.0.113.1')),
+      described_class::THROTTLED.call(request),
+      described_class::BLOCKLISTED.call(request(matched: described_class::ALLOW2BAN_NAME)),
+      described_class::BLOCKLISTED.call(request),
+    ]
+    responses.each do |_status, headers, _body|
+      expect(headers.keys).to all(satisfy { |key| key == key.downcase })
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Crawlers read our status codes as instructions. We sent two that state the opposite of what we intend.

**No 429 carried a `Retry-After` header.** The initializer set `Rack::Attack.throttled_response_retry_after_header = true`. rack-attack reads that flag only inside its `DEFAULT_THROTTLED_RESPONDER`. This file assigns a custom responder, so the flag did nothing. The custom responder returned a bare `[429, {}, ...]` for every client that was not safelisted and was not on `/api`. That is every client that the throttle actually limits. `Retry-After` is the one header that tells a client how long to wait, and no throttled response carried it.

**The allow2ban blocklist answered 403.** A ban earned by request rate is temporary. Status 403 means the URL is forbidden. It carries no idea of a later retry. Google treats 403, like 404, as a reason to remove a URL from the index. It does not treat it as a reason to slow down.

The effect is measurable. These are the responses that the declared crawlers received in the seven days to 2026-09-09:

| Crawler | Total | Responses |
|---|---|---|
| ClaudeBot | 678,841 | **625,122 x 403**, 37,322 x 429, 13,048 x 200 |
| bingbot | 52,085 | 7,040 x 429, 687 x 503, 40,956 x 200 |
| Googlebot | 8,860 | 175 x 503, 86 x 429, 1 x 403, 8,182 x 200 |

ClaudeBot received 625,122 responses that said "forbidden" and did not back off. This is the expected result. Status 403 gives a client no reason to wait.

## Guidance

Google [documents](https://developers.google.com/search/docs/crawling-indexing/reduce-crawl-rate) that a site must return 500, 503, or 429 to reduce the Googlebot crawl rate. Google also warns that these codes for more than one or two days can remove URLs from the index. Google does not list 403.

Bing reduces its rate on 429 but [does not honour `Retry-After`](https://learn.microsoft.com/en-us/answers/questions/1329326/bingbot-backoff-after-throttling). For bingbot the rate must be stated in `robots.txt`.

## Change

- Every 429 now carries `Retry-After`. The value is the remainder of the current throttle window, so a client that obeys it returns exactly when its quota resets. `RateLimit-*` still goes only to safelisted callers and to `/api`, because a quota is meaningful only to a client that knows it has one.
- A ban earned by request rate now answers 429 with `Retry-After` set to the ban length. An IP on the explicit `RACK_ATTACK_BAD_IP` list still receives 403, which is accurate for that case. rack-attack separates the two by the matched rule name. `blocklist_ip` builds an anonymous blocklist and leaves that name empty.
- `robots.txt` gives bingbot a `Crawl-delay`.
- Header names are lowercase. Rack 3 specifies this, and `Rack::ETag` and `Rack::Deflater` look them up in lowercase.

The responders move above the production guard so that specs can call them. This file had no test coverage. That is how a configuration line that did nothing stayed in it.

## Test

12 new examples in `spec/initializers/rack_attack_responders_spec.rb`. They cover the `Retry-After` value, the quota headers, the 429 for a rate-earned ban, the 403 for the manual list, and the header name case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkFVi2WDjaNzjzqjwu2pNY
