### PR TITLE
Stub one env var without rejecting every other read

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe ApplicationController do
 
     context "locked to full users" do
       before(:each) do
-        allow(ENV).to receive(:[]).with('POSTS_LOCKED_FULL').and_return('yep')
+        stub_env('POSTS_LOCKED_FULL', 'yep')
       end
 
       it "hides all posts from logged out users" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe UsersController do
     end
 
     it "requires valid fields" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       post :create, params: { secret: "ALLHAILTHECOIN", tos: true, addition: '14' }
       expect(response).to render_template(:new)
       expect(flash[:error][:message]).to eq("There was a problem completing your sign up.")
@@ -102,7 +102,7 @@ RSpec.describe UsersController do
     end
 
     it "rejects short passwords" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       user = build(:user).attributes.with_indifferent_access.merge(password: 'short', password_confirmation: 'short')
       post :create, params: { secret: 'ALLHAILTHECOIN', tos: true, addition: '14' }.merge(user: user)
       expect(response).to render_template(:new)
@@ -113,7 +113,7 @@ RSpec.describe UsersController do
     end
 
     it "signs you up" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       pass = 'testpassword'
       user = build(:user).attributes.with_indifferent_access.merge(password: pass, password_confirmation: pass, email: 'testemail@example.com')
 
@@ -132,7 +132,7 @@ RSpec.describe UsersController do
     end
 
     it "creates reader account without secret" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       pass = 'testpassword'
       user = build(:user).attributes.with_indifferent_access.merge(password: pass, password_confirmation: pass, email: 'testemail@example.com')
 
@@ -144,7 +144,7 @@ RSpec.describe UsersController do
     end
 
     it "creates reader account with upgrade lock" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       allow(ENV).to receive(:fetch).with('SIGNUPS_LOCKED', nil).and_return(nil)
       allow(ENV).to receive(:fetch).with('UPGRADES_LOCKED', nil).and_return('yep')
       pass = 'testpassword'
@@ -159,7 +159,7 @@ RSpec.describe UsersController do
     end
 
     it "allows long passwords" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       pass = 'this is a long password to test the password validation feature and to see if it accepts this'
       user = build(:user).attributes.with_indifferent_access.merge(password: pass, password_confirmation: pass)
       expect {
@@ -173,7 +173,7 @@ RSpec.describe UsersController do
     end
 
     it "strips spaces" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
+      stub_env('ACCOUNT_SECRET', 'ALLHAILTHECOIN')
       user = build(:user, username: 'withspace ').attributes
       user = user.with_indifferent_access.merge(password: 'password', password_confirmation: 'password')
       post :create, params: { secret: 'ALLHAILTHECOIN', tos: true, addition: '14' }.merge(user: user)
@@ -617,7 +617,7 @@ RSpec.describe UsersController do
     end
 
     it "requires valid secret" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('chocolate')
+      stub_env('ACCOUNT_SECRET', 'chocolate')
       user = create(:user, role_id: Permissible::READONLY)
       login_as(user)
       put :upgrade, params: { id: user.id, secret: 'vanilla' }
@@ -626,7 +626,7 @@ RSpec.describe UsersController do
     end
 
     it "handles update failures" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('chocolate')
+      stub_env('ACCOUNT_SECRET', 'chocolate')
       user = create(:user, role_id: Permissible::READONLY)
 
       allow(User).to receive(:find_by).and_call_original
@@ -641,7 +641,7 @@ RSpec.describe UsersController do
     end
 
     it "works" do
-      allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('chocolate')
+      stub_env('ACCOUNT_SECRET', 'chocolate')
       user = create(:user, role_id: Permissible::READONLY)
       login_as(user)
       put :upgrade, params: { id: user.id, secret: 'chocolate' }

--- a/spec/lib/env_helper_spec.rb
+++ b/spec/lib/env_helper_spec.rb
@@ -1,0 +1,38 @@
+# `ENV#[]` is the method the helper stubs and the method the failure came
+# through, so these examples have to call it. Style/FetchEnvVar would rewrite
+# them to `ENV.fetch`, which exercises a different method and proves nothing.
+# rubocop:disable Style/FetchEnvVar
+RSpec.describe EnvHelper do
+  # The bug this helper exists to prevent. `with` does not scope a stub to one
+  # argument; it replaces the method and rejects every other call. Any code
+  # that reads an unrelated environment variable during the example then dies.
+  it "shows why the naive stub cannot be used" do
+    allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('secret')
+    expect { ENV['SOME_OTHER_VARIABLE'] }.to raise_error(RSpec::Mocks::MockExpectationError)
+  end
+
+  it "stubs the key it is given" do
+    stub_env('ACCOUNT_SECRET', 'secret')
+    expect(ENV['ACCOUNT_SECRET']).to eq('secret')
+  end
+
+  it "leaves every other variable readable" do
+    stub_env('ACCOUNT_SECRET', 'secret')
+    expect { ENV['SOME_OTHER_VARIABLE'] }.not_to raise_error
+  end
+
+  it "returns the real value for a variable it did not stub" do
+    stub_env('ACCOUNT_SECRET', 'secret')
+    expect(ENV['RAILS_ENV']).to eq('test')
+  end
+
+  # The concrete case that broke CI: Rack initialises
+  # BUFFERED_UPLOAD_BYTESIZE_LIMIT by reading this variable when
+  # rack/multipart/parser.rb loads. If that load happens inside a stubbed
+  # example, the naive stub turns a form POST into a spec failure.
+  it "allows the read Rack makes while loading its multipart parser" do
+    stub_env('ACCOUNT_SECRET', 'secret')
+    expect { ENV['RACK_MULTIPART_BUFFERED_UPLOAD_BYTESIZE_LIMIT'] }.not_to raise_error
+  end
+end
+# rubocop:enable Style/FetchEnvVar

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe Post do
       end
 
       it "is not visible with lock on" do
-        allow(ENV).to receive(:[]).with('POSTS_LOCKED_FULL').and_return('yep')
+        stub_env('POSTS_LOCKED_FULL', 'yep')
         expect(post).not_to be_visible_to(nil)
         expect(post).not_to be_visible_to(create(:reader_user))
         expect(post).to be_visible_to(create(:user))
@@ -614,7 +614,7 @@ RSpec.describe Post do
       end
 
       it "is not visible with lock on" do
-        allow(ENV).to receive(:[]).with('POSTS_LOCKED_FULL').and_return('yep')
+        stub_env('POSTS_LOCKED_FULL', 'yep')
         expect(post).not_to be_visible_to(nil)
         expect(post).not_to be_visible_to(create(:reader_user))
         expect(post).to be_visible_to(create(:user))
@@ -646,7 +646,7 @@ RSpec.describe Post do
       end
 
       it "is visible with lock on" do
-        allow(ENV).to receive(:[]).with('POSTS_LOCKED_FULL').and_return('yep')
+        stub_env('POSTS_LOCKED_FULL', 'yep')
         expect(post).not_to be_visible_to(nil)
         expect(post).not_to be_visible_to(create(:reader_user))
         expect(post).to be_visible_to(create(:user))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,6 +71,7 @@ require 'support/spec_feature_helper'
 require 'support/spec_request_helper'
 require 'support/spec_test_helper'
 require 'support/api_test_helper'
+require 'support/env_helper'
 require 'support/posts_controller_shared'
 require 'capybara/rspec'
 
@@ -99,6 +100,7 @@ RSpec.configure do |config|
   end
 
   config.include FactoryBot::Syntax::Methods
+  config.include EnvHelper
   config.include SpecTestHelper, type: :controller
   config.include ApiTestHelper, type: :controller
   config.include SpecRequestHelper, type: :request

--- a/spec/support/env_helper.rb
+++ b/spec/support/env_helper.rb
@@ -1,0 +1,22 @@
+module EnvHelper
+  # Stubs one environment variable and leaves every other read alone.
+  #
+  # `allow(ENV).to receive(:[]).with('KEY')` looks like it constrains the stub
+  # to one key. It does not: it replaces `ENV#[]` wholesale and then declares
+  # that the only argument it will accept is that key. Any other `ENV[...]`
+  # during the example fails with "received :[] with unexpected arguments",
+  # and the code under test does not stop reading the environment just because
+  # a spec is interested in one variable.
+  #
+  # Rack's multipart parser is the live example: it reads
+  # RACK_MULTIPART_BUFFERED_UPLOAD_BYTESIZE_LIMIT (rack/multipart/parser.rb)
+  # while parsing a form POST. Whether that read lands inside a stubbed
+  # example depends on which worker runs the spec and what ran before it in
+  # the same process, so the failure appears and disappears between runs.
+  #
+  # Installing the passthrough first keeps the stub to the one key it names.
+  def stub_env(key, value)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with(key).and_return(value)
+  end
+end


### PR DESCRIPTION
## Problem

This pattern appears at 14 sites across three spec files:

```ruby
allow(ENV).to receive(:[]).with('ACCOUNT_SECRET').and_return('ALLHAILTHECOIN')
```

It reads as a stub that is limited to one key. It is not. It replaces `ENV#[]` completely, then declares that the only argument it accepts is that key. Every other environment read in the example fails with `received :[] with unexpected arguments`. The code under test does not stop reading the environment because a spec is interested in one variable.

Rack 3.2.6 made this a live failure. `rack/multipart/parser.rb` initialises `BUFFERED_UPLOAD_BYTESIZE_LIMIT` by reading `RACK_MULTIPART_BUFFERED_UPLOAD_BYTESIZE_LIMIT`. It does this when the constant is defined, not on each request. If that file first loads inside a stubbed example, the form POST in a `users#create` spec fails on the stub instead of on the behaviour under test:

```
Failure/Error: post :create, params: { secret: "ALLHAILTHECOIN", tos: true, addition: '14' }.merge(user: user)
  received :[] with unexpected arguments
    expected: ("ACCOUNT_SECRET")
         got: ("RACK_MULTIPART_BUFFERED_UPLOAD_BYTESIZE_LIMIT")
```

The load happens once per process. The failure therefore depends on which parallel worker runs the spec, and on what ran before it in that worker. It appears and disappears between runs, on branches that changed none of this code. It failed the `rspec suite` check on #2885, which touches only `AnonLoadShed`.

## Change

`stub_env` installs an `and_call_original` passthrough before the keyed stub. The stub then applies to the one key it names, and all other reads reach the real environment.

```ruby
def stub_env(key, value)
  allow(ENV).to receive(:[]).and_call_original
  allow(ENV).to receive(:[]).with(key).and_return(value)
end
```

All 14 call sites move to it.

## Test

`spec/lib/env_helper_spec.rb` has 5 examples. The first one reproduces the original failure, so the reason for the helper stays visible if somebody writes the naive stub again. One more example covers the exact Rack read that failed in CI.

`rspec spec/controllers/users_controller_spec.rb spec/controllers/application_controller_spec.rb spec/models/post_spec.rb spec/lib/env_helper_spec.rb` gives 285 examples and 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkFVi2WDjaNzjzqjwu2pNY
